### PR TITLE
Add textmate file extensions that unique to IBM i projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,12 +336,6 @@
     },
       "languages": [
           {
-              "id": "bnd",
-              "extensions": [
-                  ".bnd"
-              ]
-          },
-          {
               "id": "cl",
               "extensions": [
                 ".cl",
@@ -408,8 +402,7 @@
               ".sqlvar",
               ".sqlxsr",
               ".table",
-              ".view",
-              ".cblle"
+              ".view"
             ]
           }
       ],

--- a/package.json
+++ b/package.json
@@ -334,6 +334,85 @@
         }
       ]
     },
+      "languages": [
+          {
+              "id": "bnd",
+              "extensions": [
+                  ".bnd"
+              ]
+          },
+          {
+              "id": "cl",
+              "extensions": [
+                ".cl",
+                ".clp",
+                ".clp38",
+                ".bnddir",
+                ".bnddirsrc",
+                ".clle",
+                ".pgm.clle",
+                ".cls",
+                ".cmd",
+                ".dtaara",
+                ".dtaq",
+                ".jobd",
+                ".jobq",
+                ".msgd",
+                ".msgf",
+                ".msgq",
+                ".outq",
+                ".sbsd",
+                ".seqview",
+                ".systrg",
+                ".ilepgm",
+                ".ilesrvpgm"
+              ]
+          },
+          {
+              "id": "cmd",
+              "extensions": [
+                  ".cmd",
+                  ".cmdsrc"
+              ]
+          },
+          {
+            "id": "pnlgrp",
+            "aliases": [
+              "PNLGRP",
+              "IBM UIM Panel Group Definition Language"
+          ],
+            "extensions": [
+                ".pnlgrp",
+                ".pnlgrpsrc",
+                ".menusrc",
+                ".menu"
+            ]
+          },
+          {
+            "id": "sql",
+            "aliases": [
+              "sql"
+            ],
+            "extensions": [
+              ".sql",
+              ".sqlalias",
+              ".sqlc",
+              ".sqlcpp",
+              ".sqlmask",
+              ".sqlperm",
+              ".sqlprc",
+              ".sqlseq",
+              ".sqltrg",
+              ".sqludf",
+              ".sqludt",
+              ".sqlvar",
+              ".sqlxsr",
+              ".table",
+              ".view",
+              ".cblle"
+            ]
+          }
+      ],
     "colors": [
       {
         "id": "projectExplorer.activeProject",


### PR DESCRIPTION
vscode-ibmi-languages provides textmate grammers for all of the IBM i languages.
The IBM i project model has additional file extensions.
For example a number of objects like DTAARA have their own .dtaara file extension and should map to "cl".
Likewise a number of SQL objects like .table should map to "sql"