### PR TITLE
Gave explicit type to event's callback function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-ibmi-projectexplorer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-ibmi-projectexplorer",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.3",


### PR DESCRIPTION
The event callback function type was defined using the generic `Function` type. This PR defines a specific type for the callback function, with explcit parameters, making it easier for other extensions to use this API.