### PR TITLE
Fixed explorer crashing on non string values in iproj.json

### DIFF
--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -7,11 +7,11 @@ import * as dotenv from 'dotenv';
 import { ValidatorResult } from "jsonschema";
 import * as path from "path";
 import { TextEncoder } from "util";
-import { commands, l10n, Uri, window, workspace, WorkspaceFolder } from "vscode";
+import { Uri, WorkspaceFolder, commands, l10n, window, workspace } from "vscode";
 import envUpdater from "./envUpdater";
+import { IProjectT } from "./iProjectT";
 import { getDeployTools, getInstance } from "./ibmi";
 import { IBMiJsonT } from "./ibmiJsonT";
-import { IProjectT } from "./iProjectT";
 import { JobLogInfo } from "./jobLog";
 import { ProjectManager } from "./projectManager";
 import { RingBuffer } from "./views/jobLog/RingBuffer";
@@ -130,7 +130,7 @@ export class IProject {
    * @returns A uri of the desired resource.
    */
   public getProjectFileUri(type: ProjectFileType, directory?: Uri): Uri {
-    const logDirectory = (type === 'joblog.json' || type === 'output.log' || type.endsWith('.splf') ) ? `.logs` : ``;
+    const logDirectory = (type === 'joblog.json' || type === 'output.log' || type.endsWith('.splf')) ? `.logs` : ``;
 
     return Uri.file(path.join(directory ? directory.fsPath : this.workspaceFolder.uri.fsPath, logDirectory, type));
   }
@@ -1159,12 +1159,12 @@ export class IProject {
         .map(ibmiJson => ibmiJson.build!.objlib) : [])
     ].filter(x => x) as string[];
 
-    // Get everything that starts with an &
-    const variableNameList = valueList.filter(value => value.startsWith(`&`)).map(value => value.substring(1));
-
-    // Remove duplicates
-    return variableNameList.filter((name,
-      index) => variableNameList.indexOf(name) === index);
+    // Get every unique string value that starts with an &
+    return valueList
+      .filter(value => typeof value === "string")
+      .filter(value => value.startsWith(`&`))
+      .map(value => value.substring(1))            
+      .filter((value, index, array) => array.indexOf(value) === index);
   }
 
   /**


### PR DESCRIPTION
The Project Explorer crashes if there are some non string value in `iproj.json`. This can happen in the extensions section of the `iproj.json` file. The following error is shown in the notification area:
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11096890/1c5cc762-5333-4fb3-84ed-36cdcc76be43)

This is due to the code looking for variable values (i.e. values strting with `&`).

This example reproduces the issue:
```json
{
  "description": "Demo project",
  "version": "0.0.1",
  "includePath": [
    "SOURCES/QPROTOSRC"
  ],
  "objlib": "&OBJLIB",
  "curlib": "&CURLIB",
  "extensions": {
    "skynet": {
      "code": "T1000",
      "id": 42,
      "active": true
    }
  }
}
```
This PR fixes this issue by making sure only the string values from `iproj.json` are kept when looking for variable values.