### PR TITLE
Fixed launch configuration to run actual watch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,8 @@
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
 			],
-			"preLaunchTask": "npm: compile"
+			"sourceMaps": true,
+			"preLaunchTask": "${defaultBuildTask}"
 		},
 		{
 			"name": "Extension Tests",
@@ -28,7 +29,7 @@
 				"${workspaceFolder}/dist/**/*.js"
 			],			
 			"sourceMaps": true,
-			"preLaunchTask": "npm: compile",
+			"preLaunchTask": "${defaultBuildTask}",
 			"env": {
 				"testing": "true"
 			}


### PR DESCRIPTION
The launch configuration did not call the default `watch` task but `npm compile` instead. As a result, starting a debug sessions would not watch the code for modifications, making debug sessions less efficient.