### PR TITLE
Fix/uppercase variable assignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-ibmi-projectexplorer",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-ibmi-projectexplorer",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.3",

--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -701,7 +701,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
 
                 if (variable) {
                   await activeProject.updateEnv(variable.label.substring(1), 
-                  value.toLocaleUpperCase().startsWith("QSYS/") ? value.toLocaleUpperCase(): value);
+                  value.toLocaleUpperCase().startsWith("QSYS/") ? value.substring(5).toLocaleUpperCase(): value);
                 }
               } else {
                 window.showErrorMessage(l10n.t('No variables found'));

--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -696,7 +696,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
                 }
 
                 const variable = await window.showQuickPick(variableItems, {
-                  placeHolder: l10n.t('Select  a variable')
+                  placeHolder: l10n.t('Select a variable')
                 });
 
                 if (variable) {

--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -696,11 +696,12 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
                 }
 
                 const variable = await window.showQuickPick(variableItems, {
-                  placeHolder: l10n.t('Select a variable')
+                  placeHolder: l10n.t('Select  a variable')
                 });
 
                 if (variable) {
-                  await activeProject.updateEnv(variable.label.substring(1), value);
+                  await activeProject.updateEnv(variable.label.substring(1), 
+                  value.toLocaleUpperCase().startsWith("QSYS/") ? value.toLocaleUpperCase(): value);
                 }
               } else {
                 window.showErrorMessage(l10n.t('No variables found'));


### PR DESCRIPTION
Fixes https://github.com/IBM/vscode-ibmi-projectexplorer/issues/251
Library names in Code for i can be lowercase depending on the user settings.
This PR makes sure that library paths are always assigned uppercase.