### PR TITLE
For unspecified build commands, prefill prompt with BOB commands and invoke command after prompting

### DIFF
--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -487,25 +487,17 @@ export class IProject {
       let command = isBuild ? unresolvedState.buildCommand : unresolvedState.compileCommand;
       if (!command) {
         if (isBuild) {
-          window.showErrorMessage(l10n.t('Project\'s build command not set'), l10n.t('Set Build Command'))
-            .then(async (item) => {
-              if (item === l10n.t('Set Build Command')) {
-                await commands.executeCommand(`vscode-ibmi-projectexplorer.projectExplorer.setBuildCommand`, this);
-              }
-            })
-            .then(async () => 
-              {this.runBuildOrCompileCommand(isBuild, fileUri);}
-            );
+          const selection = await window.showErrorMessage(l10n.t('Project\'s build command not set'), l10n.t('Set Build Command'));
+          if (selection === l10n.t('Set Build Command')) {
+            await commands.executeCommand(`vscode-ibmi-projectexplorer.projectExplorer.setBuildCommand`, this);
+            this.runBuildOrCompileCommand(isBuild, fileUri);
+          }
         } else {
-          window.showErrorMessage(l10n.t('Project\'s compile command not set'), l10n.t('Set Compile Command'))
-            .then(async (item) => {
-              if (item === l10n.t('Set Compile Command')) {
-                await commands.executeCommand(`vscode-ibmi-projectexplorer.projectExplorer.setCompileCommand`, this);
-              }
-            })
-            .then(async () => 
-              {this.runBuildOrCompileCommand(isBuild, fileUri);}
-            );
+          const selection = await window.showErrorMessage(l10n.t('Project\'s compile command not set'), l10n.t('Set Compile Command'));
+          if (selection === l10n.t('Set Compile Command')) {
+            await commands.executeCommand(`vscode-ibmi-projectexplorer.projectExplorer.setCompileCommand`, this);
+            this.runBuildOrCompileCommand(isBuild, fileUri);
+          }
         }
       } else {
         this.runBuildOrCompileCommand(isBuild, fileUri);

--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -470,22 +470,45 @@ export class IProject {
         };
         await commands.executeCommand(`code-for-ibmi.runAction`, { resourceUri: fileUri ? fileUri : this.workspaceFolder.uri }, undefined, action, this.deploymentMethod);
         ProjectManager.fire({ type: isBuild ? 'build' : 'compile', iProject: this });
-      } else {
+      } 
+    }
+  }
+  /**
+   * Run the project's build or compile command.
+   * If no command is specified prompt for it and then run the provided command
+   * 
+   * @param isBuild True for build command and false for compile command.
+   * @param fileUri The file uri to compile or `undefined` for builds.
+   */
+  public async runBuildOrCompileCommandWithPrompt(isBuild: boolean, fileUri?: Uri) {
+    let unresolvedState = await this.getUnresolvedState();
+
+    if (unresolvedState) {
+      let command = isBuild ? unresolvedState.buildCommand : unresolvedState.compileCommand;
+      if (!command) {
         if (isBuild) {
           window.showErrorMessage(l10n.t('Project\'s build command not set'), l10n.t('Set Build Command'))
             .then(async (item) => {
               if (item === l10n.t('Set Build Command')) {
                 await commands.executeCommand(`vscode-ibmi-projectexplorer.projectExplorer.setBuildCommand`, this);
               }
-            });
+            })
+            .then(async () => 
+              {this.runBuildOrCompileCommand(isBuild, fileUri);}
+            );
         } else {
           window.showErrorMessage(l10n.t('Project\'s compile command not set'), l10n.t('Set Compile Command'))
             .then(async (item) => {
               if (item === l10n.t('Set Compile Command')) {
                 await commands.executeCommand(`vscode-ibmi-projectexplorer.projectExplorer.setCompileCommand`, this);
               }
-            });
+            })
+            .then(async () => 
+              {this.runBuildOrCompileCommand(isBuild, fileUri);}
+            );
         }
+      } else {
+        this.runBuildOrCompileCommand(isBuild, fileUri);
       }
     }
   }

--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -150,10 +150,14 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
             const unresolvedState = await iProject.getUnresolvedState();
 
             if (unresolvedState) {
+              let defaultCommand = '/QOpenSys/pkgs/bin/makei build';
+              if (unresolvedState.compileCommand) {
+                defaultCommand = unresolvedState.compileCommand;
+              }
               const command = await window.showInputBox({
                 prompt: l10n.t('Enter compile command ({0} resolves to the base file name being edited. {1} resolves to the full IFS path corresponding to the source in the editor. {2} resolves to the IBM i hostname. {3} resolves to the user profile that the command will be executed under. {4} resolves to the name of the current git branch if this project is managed by git.)', '{filename}', '{path}', '{host}', '{usrprf}', '{branch}'),
                 placeHolder: l10n.t('Compile command'),
-                value: unresolvedState.compileCommand,
+                value: defaultCommand,
               });
 
               if (command) {

--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -88,29 +88,32 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
         }
       }),
       commands.registerCommand(`vscode-ibmi-projectexplorer.projectExplorer.setBuildCommand`, async (element: Project) => {
+        let iProject: IProject | undefined;
         if (element) {
-          const iProject = ProjectManager.get(element.workspaceFolder);
+          iProject = ProjectManager.get(element.workspaceFolder);
+        } else {
+          iProject = ProjectManager.getActiveProject();
+        }
 
-          if (iProject) {
-            const unresolvedState = await iProject.getUnresolvedState();
-            if (unresolvedState) {
-              let defaultCommand = '/QOpenSys/pkgs/bin/makei build';
-              if (unresolvedState.buildCommand) {
-                defaultCommand = unresolvedState.buildCommand;
-              }
-              const command = await window.showInputBox({
-                prompt: l10n.t('Enter build command ({0} resolves to the base file name being edited. {1} resolves to the full IFS path corresponding to the source in the editor. {2} resolves to the IBM i hostname. {3} resolves to the user profile that the command will be executed under. {4} resolves to the name of the current git branch if this project is managed by git.)', '{filename}', '{path}', '{host}', '{usrprf}', '{branch}'),
-                placeHolder: l10n.t('Build command'),
-                value: defaultCommand,
-              });
-
-              if (command) {
-                await iProject.setBuildOrCompileCommand(command, true);
-              }
+        if (iProject) {
+          const unresolvedState = await iProject.getUnresolvedState();
+          if (unresolvedState) {
+            let defaultCommand = '/QOpenSys/pkgs/bin/makei build';
+            if (unresolvedState.buildCommand) {
+              defaultCommand = unresolvedState.buildCommand;
             }
-          } else {
-            window.showErrorMessage(l10n.t('Failed to retrieve project'));
+            const command = await window.showInputBox({
+              prompt: l10n.t('Enter build command ({0} resolves to the base file name being edited. {1} resolves to the full IFS path corresponding to the source in the editor. {2} resolves to the IBM i hostname. {3} resolves to the user profile that the command will be executed under. {4} resolves to the name of the current git branch if this project is managed by git.)', '{filename}', '{path}', '{host}', '{usrprf}', '{branch}'),
+              placeHolder: l10n.t('Build command'),
+              value: defaultCommand,
+            });
+
+            if (command) {
+              await iProject.setBuildOrCompileCommand(command, true);
+            }
           }
+        } else {
+          window.showErrorMessage(l10n.t('Failed to retrieve project'));
         }
       }),
       commands.registerCommand(`vscode-ibmi-projectexplorer.projectExplorer.runCompile`, async (element?: SourceFile | SourceDirectory | Uri) => {
@@ -143,30 +146,33 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
         }
       }),
       commands.registerCommand(`vscode-ibmi-projectexplorer.projectExplorer.setCompileCommand`, async (element: Project) => {
+        let iProject: IProject | undefined;
         if (element) {
-          const iProject = ProjectManager.get(element.workspaceFolder);
+          iProject = ProjectManager.get(element.workspaceFolder);
+        } else {
+          iProject = ProjectManager.getActiveProject();
+        }
 
-          if (iProject) {
-            const unresolvedState = await iProject.getUnresolvedState();
+        if (iProject) {
+          const unresolvedState = await iProject.getUnresolvedState();
 
-            if (unresolvedState) {
-              let defaultCommand = '/QOpenSys/pkgs/bin/makei compile -f {filename}';
-              if (unresolvedState.compileCommand) {
-                defaultCommand = unresolvedState.compileCommand;
-              }
-              const command = await window.showInputBox({
-                prompt: l10n.t('Enter compile command ({0} resolves to the base file name being edited. {1} resolves to the full IFS path corresponding to the source in the editor. {2} resolves to the IBM i hostname. {3} resolves to the user profile that the command will be executed under. {4} resolves to the name of the current git branch if this project is managed by git.)', '{filename}', '{path}', '{host}', '{usrprf}', '{branch}'),
-                placeHolder: l10n.t('Compile command'),
-                value: defaultCommand,
-              });
-
-              if (command) {
-                await iProject.setBuildOrCompileCommand(command, false);
-              }
+          if (unresolvedState) {
+            let defaultCommand = '/QOpenSys/pkgs/bin/makei compile -f {filename}';
+            if (unresolvedState.compileCommand) {
+              defaultCommand = unresolvedState.compileCommand;
             }
-          } else {
-            window.showErrorMessage(l10n.t('Failed to retrieve project'));
+            const command = await window.showInputBox({
+              prompt: l10n.t('Enter compile command ({0} resolves to the base file name being edited. {1} resolves to the full IFS path corresponding to the source in the editor. {2} resolves to the IBM i hostname. {3} resolves to the user profile that the command will be executed under. {4} resolves to the name of the current git branch if this project is managed by git.)', '{filename}', '{path}', '{host}', '{usrprf}', '{branch}'),
+              placeHolder: l10n.t('Compile command'),
+              value: defaultCommand,
+            });
+
+            if (command) {
+              await iProject.setBuildOrCompileCommand(command, false);
+            }
           }
+        } else {
+          window.showErrorMessage(l10n.t('Failed to retrieve project'));
         }
       }),
       commands.registerCommand(`vscode-ibmi-projectexplorer.projectExplorer.launchActionsSetup`, async (element: Project) => {

--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -82,7 +82,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
         }
 
         if (iProject) {
-          iProject.runBuildOrCompileCommand(true);
+          iProject.runBuildOrCompileCommandWithPrompt(true);
         } else {
           window.showErrorMessage(l10n.t('Failed to retrieve project'));
         }
@@ -137,7 +137,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
         }
 
         if (iProject) {
-          iProject.runBuildOrCompileCommand(false, element);
+          iProject.runBuildOrCompileCommandWithPrompt(false, element);
         } else {
           window.showErrorMessage(l10n.t('Failed to retrieve project'));
         }

--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -150,7 +150,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
             const unresolvedState = await iProject.getUnresolvedState();
 
             if (unresolvedState) {
-              let defaultCommand = '/QOpenSys/pkgs/bin/makei build';
+              let defaultCommand = '/QOpenSys/pkgs/bin/makei compile -f {filename}';
               if (unresolvedState.compileCommand) {
                 defaultCommand = unresolvedState.compileCommand;
               }

--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -93,12 +93,15 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
 
           if (iProject) {
             const unresolvedState = await iProject.getUnresolvedState();
-
             if (unresolvedState) {
+              let defaultCommand = '/QOpenSys/pkgs/bin/makei build';
+              if (unresolvedState.buildCommand) {
+                defaultCommand = unresolvedState.buildCommand;
+              }
               const command = await window.showInputBox({
                 prompt: l10n.t('Enter build command ({0} resolves to the base file name being edited. {1} resolves to the full IFS path corresponding to the source in the editor. {2} resolves to the IBM i hostname. {3} resolves to the user profile that the command will be executed under. {4} resolves to the name of the current git branch if this project is managed by git.)', '{filename}', '{path}', '{host}', '{usrprf}', '{branch}'),
                 placeHolder: l10n.t('Build command'),
-                value: unresolvedState.buildCommand,
+                value: defaultCommand,
               });
 
               if (command) {


### PR DESCRIPTION
When there is no build or compile command in the iproj.json, invoking the build or compile prompts the user for a new command.

### For Build
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11184579/2118f50d-5eb6-42ed-a3b6-2819427f7ce0)
 
if you press 'Set Build Command', the prompt is *now* prefilled with the BOB build command
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11184579/004d4bc5-bcab-41e0-b62c-111c9853be3f)

After specifying the command, the command is *now* actually invoked instead of forcing the user to invoke it again.
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11184579/7ade96fa-76b5-4935-a50c-fc04100c64ec)

### For Compile
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11184579/5601e863-2f20-4756-9440-5320d922cd64)

if you press 'Set Build Command', the prompt is *now* prefilled with the BOB build command
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11184579/127a89d5-a045-4643-aae3-0619d959dea1)

After specifying the command, the command is *now* actually invoked instead of forcing the user to invoke it again.

![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11184579/559cf632-3d30-427f-8156-72e55b27d87f)


###  set build/compile commands from command palette
Returned without doing anything because not project was passed in.  Now the active project is computed in this scenario and it will work. 