### PR TITLE
Changed IBM i panel to IBM i Project Explorer

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -92,7 +92,7 @@
   "description": "Develop IBM i applications using buildable local projects in VS Code",
   "explorer.projectExplorer": "Project Explorer",
   "ibmi.jobLog": "Job Log",
-  "panel.ibmi": "IBM i",
+  "panel.ibmi": "IBM i Project Explorer",
   "submenus.projectExplorer.gotTo": "Go To...",
   "submenus.projectExplorer.run": "Run...",
   "viewsWelcome.jobLog.noWorkspace": "No workspace folder opened",


### PR DESCRIPTION
The Project Explorer's panel is just IBM in which may be confusing (e.g. the DB2 extension displays the same title for its result view):
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11096890/c0e19651-77a6-43a6-918b-beef6be2e1bf)

This PR changes the title to make it more explicit:
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11096890/e0103d49-11fa-41d2-8347-9043d5da8c27)
