### PR TITLE
Make library type more explicit

### DIFF
--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -34,8 +34,8 @@ export type ProjectFileType = 'iproj.json' | '.ibmi.json' | 'joblog.json' | 'out
 /**
  * Represents a project's library list.
  */
-export type LibraryLocation = 'SYS' | 'CUR' | 'USR';
-export type LibraryList = { libraryInfo: IBMiObject; libraryType: LibraryLocation; }[];
+export type LibraryListPortion = 'SYS' | 'CUR' | 'USR';
+export type LibraryList = { libraryInfo: IBMiObject; libraryListPortion: LibraryListPortion; }[];
 
 /**
  * Represents the environment variables in a `.env` file.
@@ -828,7 +828,7 @@ export class IProject {
           if (libraryListString !== ``) {
             const libraries = libraryListString.split(`\n`);
 
-            const libraryList: { name: string, libraryType: LibraryLocation }[] = [];
+            const libraryList: { name: string, libraryType: LibraryListPortion }[] = [];
             for (const library of libraries) {
               libraryList.push({
                 name: library.substring(0, 10).trim(),
@@ -841,7 +841,7 @@ export class IProject {
               for (const [index, library] of libraryList.entries()) {
                 libl.push({
                   libraryInfo: libraryListInfo[index],
-                  libraryType: library.libraryType
+                  libraryListPortion: library.libraryType
                 });
               }
 
@@ -1358,7 +1358,7 @@ export class IProject {
   }
 }
 
-function toLibraryLocation(location: string): LibraryLocation {
+function toLibraryLocation(location: string): LibraryListPortion {
   if (location === 'USR' || location === 'SYS' || location === 'CUR') {
     return location;
   }

--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -34,7 +34,8 @@ export type ProjectFileType = 'iproj.json' | '.ibmi.json' | 'joblog.json' | 'out
 /**
  * Represents a project's library list.
  */
-export type LibraryList = { libraryInfo: IBMiObject; libraryType: string; }[];
+export type LibraryLocation = 'SYS' | 'CUR' | 'USR';
+export type LibraryList = { libraryInfo: IBMiObject; libraryType: LibraryLocation; }[];
 
 /**
  * Represents the environment variables in a `.env` file.
@@ -827,14 +828,13 @@ export class IProject {
           if (libraryListString !== ``) {
             const libraries = libraryListString.split(`\n`);
 
-            let libraryList: { name: string, libraryType: string }[] = [];
+            const libraryList: { name: string, libraryType: LibraryLocation }[] = [];
             for (const library of libraries) {
               libraryList.push({
-                name: library.substring(0, 10).trim(),
-                libraryType: library.substring(12)
+                name: library.substring(0, 10).trim(),                
+                libraryType: toLibraryLocation(library.substring(12))
               });
             }
-
             const libraryListInfo = await ibmi.getContent().getLibraryList(libraryList.map(lib => lib.name));
             if (libraryListInfo) {
               let libl = [];
@@ -1355,5 +1355,15 @@ export class IProject {
     } else {
       this.jobLogs.fromArray([]);
     }
+  }
+}
+
+function toLibraryLocation(location:string) : LibraryLocation {
+  if(location === 'USR' || location === 'SYS' || location === 'CUR'){
+    return location;
+  }
+  else{
+    //Should not happen
+    return 'USR';
   }
 }

--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -274,7 +274,7 @@ export class IProject {
       const validator = ProjectManager.getValidator();
       const schema = validator.schemas['/iproj'];
       const validatorResult = validator.validate(unresolvedState || content, schema);
-  
+
       if (validatorResult && validatorResult.errors.length > 0 && content.trim() !== '') {
         this.validatorResult = validatorResult;
         return undefined;
@@ -471,7 +471,7 @@ export class IProject {
         };
         await commands.executeCommand(`code-for-ibmi.runAction`, { resourceUri: fileUri ? fileUri : this.workspaceFolder.uri }, undefined, action, this.deploymentMethod);
         ProjectManager.fire({ type: isBuild ? 'build' : 'compile', iProject: this });
-      } 
+      }
     }
   }
   /**
@@ -831,7 +831,7 @@ export class IProject {
             const libraryList: { name: string, libraryType: LibraryLocation }[] = [];
             for (const library of libraries) {
               libraryList.push({
-                name: library.substring(0, 10).trim(),                
+                name: library.substring(0, 10).trim(),
                 libraryType: toLibraryLocation(library.substring(12))
               });
             }
@@ -1181,7 +1181,7 @@ export class IProject {
     return valueList
       .filter(value => typeof value === "string")
       .filter(value => value.startsWith(`&`))
-      .map(value => value.substring(1))            
+      .map(value => value.substring(1))
       .filter((value, index, array) => array.indexOf(value) === index);
   }
 
@@ -1358,11 +1358,11 @@ export class IProject {
   }
 }
 
-function toLibraryLocation(location:string) : LibraryLocation {
-  if(location === 'USR' || location === 'SYS' || location === 'CUR'){
+function toLibraryLocation(location: string): LibraryLocation {
+  if (location === 'USR' || location === 'SYS' || location === 'CUR') {
     return location;
   }
-  else{
+  else {
     //Should not happen
     return 'USR';
   }

--- a/src/testing/suites/iProject.ts
+++ b/src/testing/suites/iProject.ts
@@ -3,15 +3,15 @@
  */
 
 import * as assert from "assert";
-import { TestSuite } from "..";
 import * as path from "path";
-import { ProjectManager } from "../../projectManager";
-import { ProjectFileType } from "../../iproject";
-import { LibraryType } from "../../views/projectExplorer/library";
-import { workspace } from "vscode";
-import { getDeployTools, getInstance } from "../../ibmi";
-import { iProjectMock, ibmiJsonMock } from "../constants";
 import { TextEncoder } from "util";
+import { workspace } from "vscode";
+import { TestSuite } from "..";
+import { getDeployTools, getInstance } from "../../ibmi";
+import { ProjectFileType } from "../../iproject";
+import { ProjectManager } from "../../projectManager";
+import { LibraryType } from "../../views/projectExplorer/library";
+import { iProjectMock, ibmiJsonMock } from "../constants";
 
 let deployLocation: string;
 
@@ -385,7 +385,7 @@ export const iProjectSuite: TestSuite = {
                             attribute: 'TEST',
                             text: 'Test Library'
                         },
-                        libraryType: 'USR'
+                        libraryListPortion: 'USR'
                     }
                 ]);
                 const libraryList = await iProject.getLibraryList();

--- a/src/views/projectExplorer/libraryList.ts
+++ b/src/views/projectExplorer/libraryList.ts
@@ -3,12 +3,12 @@
  */
 
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState, WorkspaceFolder, l10n, window } from "vscode";
-import { ProjectExplorerTreeItem } from "./projectExplorerTreeItem";
+import { getInstance } from "../../ibmi";
 import { ContextValue } from "../../ibmiProjectExplorer";
+import { Position } from "../../iproject";
 import { ProjectManager } from "../../projectManager";
 import Library, { LibraryType } from "./library";
-import { Position } from "../../iproject";
-import { getInstance } from "../../ibmi";
+import { ProjectExplorerTreeItem } from "./projectExplorerTreeItem";
 
 /**
  * Tree item for the Library List heading.
@@ -37,7 +37,7 @@ export default class LibraryList extends TreeItem implements ProjectExplorerTree
         for (const library of libraryList) {
           let variable = undefined;
 
-          switch (library.libraryType) {
+          switch (library.libraryListPortion) {
             case `SYS`:
               items.push(new Library(this.workspaceFolder, library.libraryInfo, LibraryType.systemLibrary));
               break;


### PR DESCRIPTION
Since the library type can only be `SYS`, `CUR`, or `USR`, it's clearer to make it explicit.