### PR TITLE
Fix missing deleted files in sub-directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -949,7 +949,7 @@
         },
         {
           "command": "vscode-ibmi-projectexplorer.projectExplorer.compareWithRemote",
-          "when": "view == projectExplorer && viewItem =~ /^sourceFile.*/",
+          "when": "view == projectExplorer && viewItem =~ /^sourceFile(?!(_deleted)).*/",
           "group": "1_compare@0"
         },
         {
@@ -1024,7 +1024,7 @@
         },
         {
           "command": "vscode-ibmi-projectexplorer.projectExplorer.runCompile",
-          "when": "view == projectExplorer && viewItem =~ /^(sourceFile|sourceDirectory).*/",
+          "when": "view == projectExplorer && viewItem =~ /^(sourceFile(?!(_deleted))|sourceDirectory).*/",
           "group": "1_iproj@3"
         },
         {

--- a/src/ibmiProjectExplorer.ts
+++ b/src/ibmiProjectExplorer.ts
@@ -40,6 +40,7 @@ export enum ContextValue {
   active = '_active',
   source = 'source',
   sourceFile = 'sourceFile',
+  deleted = '_deleted',
   sourceDirectory = 'sourceDirectory',
   variables = 'variables',
   variable = 'variable',

--- a/src/views/projectExplorer/deletedFile.ts
+++ b/src/views/projectExplorer/deletedFile.ts
@@ -2,30 +2,23 @@
  * (c) Copyright IBM Corp. 2024
  */
 
-import { ThemeIcon, TreeItem, TreeItemCollapsibleState, WorkspaceFolder, l10n } from "vscode";
-import { ProjectExplorerTreeItem } from "./projectExplorerTreeItem";
+import { ThemeIcon, WorkspaceFolder, l10n } from "vscode";
 import { ContextValue } from "../../ibmiProjectExplorer";
 import { SourceInfo } from "./source";
+import SourceFile from "./sourceFile";
 
 /**
- * Tree item for a source file
+ * Tree item for a deleted source file
  */
-export default class DeletedFile extends TreeItem implements ProjectExplorerTreeItem {
+export default class DeletedFile extends SourceFile {
   static contextValue = ContextValue.sourceFile;
-  sourceInfo: SourceInfo;
 
   constructor(public workspaceFolder: WorkspaceFolder, sourceFileInfo: SourceInfo) {
-    super(sourceFileInfo.name, TreeItemCollapsibleState.None);
+    super(workspaceFolder, sourceFileInfo);
 
-    this.sourceInfo = sourceFileInfo;
-    this.contextValue = DeletedFile.contextValue;
     this.iconPath = new ThemeIcon(`trash`);
-    this.tooltip = l10n.t('Delete upon deploy\n') + l10n.t('Name: {0}\n', sourceFileInfo.name) +
-      l10n.t('Path: {0}', sourceFileInfo.localUri.fsPath);
-    this.resourceUri = sourceFileInfo.localUri;
-  }
-
-  getChildren(): ProjectExplorerTreeItem[] {
-    return [];
+    this.tooltip = l10n.t('Delete Upon Deploy\n') + this.tooltip;
+    this.command = undefined;
+    this.contextValue = DeletedFile.contextValue + ContextValue.deleted;
   }
 }

--- a/src/views/projectExplorer/source.ts
+++ b/src/views/projectExplorer/source.ts
@@ -126,7 +126,7 @@ export default class Source extends TreeItem implements ProjectExplorerTreeItem 
           subTree = subTree.children[index];
         } else {
           const localUri = Uri.joinPath(subTree.localUri, part);
-          var fileType : FileType;
+          let fileType : FileType;
           try {
             const statResult = await workspace.fs.stat(localUri);
             fileType = statResult.type;

--- a/src/views/projectExplorer/sourceDirectory.ts
+++ b/src/views/projectExplorer/sourceDirectory.ts
@@ -7,6 +7,7 @@ import { ProjectExplorerTreeItem } from "./projectExplorerTreeItem";
 import { ContextValue } from "../../ibmiProjectExplorer";
 import { SourceInfo } from "./source";
 import SourceFile from "./sourceFile";
+import DeletedFile from "./deletedFile";
 
 /**
  * Tree item for a source directory
@@ -31,9 +32,10 @@ export default class SourceDirectory extends TreeItem implements ProjectExplorer
 
         for (const child of this.sourceInfo.children) {
             try {
-                const statResult = await workspace.fs.stat(child.localUri);
-                if (statResult.type === FileType.Directory) {
+                if (child.type === FileType.Directory) {
                     items.push(new SourceDirectory(this.workspaceFolder, child));
+                } else if (child.type === FileType.Unknown) { // File was deleted so we switched to Unknown on catch
+                    items.push(new DeletedFile(this.workspaceFolder, child));
                 } else {
                     items.push(new SourceFile(this.workspaceFolder, child));
                 }


### PR DESCRIPTION
Fixes #345

@edmundreinhardt Your change in #327 was good, but only showed deleted files at the root of the project. This PR includes the logic you added but when also expanding directories. I also removed some duplicate code as the `DeletedFile` class can simply extend `SourceFile`.