### PR TITLE
Fix/377 support doublequoted libraries

### DIFF
--- a/src/testing/constants.ts
+++ b/src/testing/constants.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /*
  * (c) Copyright IBM Corp. 2023
  */

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -15,6 +15,7 @@ import { jobLogCommandSuite } from "./suites/jobLogCommand";
 import { jobLogTreeItemSuite } from "./suites/jobLogTreeItem";
 import { ringBufferSuite } from "./suites/ringBuffer";
 import { buildMapSuite } from "./suites/buildMap";
+import { utilSuite } from "./suites/utilTest";
 
 const suites: TestSuite[] = [
   buildMapSuite,
@@ -25,7 +26,8 @@ const suites: TestSuite[] = [
   jobLogTreeItemSuite,
   projectExplorerTreeItemSuite,
   projectManagerSuite,
-  ringBufferSuite
+  ringBufferSuite,
+  utilSuite
 ];
 
 export type TestSuite = {

--- a/src/testing/suites/iProject.ts
+++ b/src/testing/suites/iProject.ts
@@ -562,6 +562,7 @@ export const iProjectSuite: TestSuite = {
                     "path1": '',
                     "path2": '',
                     "valueA": '',
+                    "DTALIB": '',
                 });
             }
         },
@@ -580,6 +581,7 @@ export const iProjectSuite: TestSuite = {
                     "path1": 'PATH1',
                     "path2": '',
                     "valueA": 'VALUEA',
+                    "DTALIB": '',
                 });
             }
         },
@@ -600,7 +602,8 @@ export const iProjectSuite: TestSuite = {
                     "path1": 'PATH1',
                     "path2": '',
                     "valueA": 'VALUEA',
-                    "var": 'VAR'
+                    "var": 'VAR',
+                    "DTALIB": ''
                 });
             }
         },
@@ -627,7 +630,7 @@ export const iProjectSuite: TestSuite = {
                 const iProject = ProjectManager.getProjects()[0];
                 const variables = await iProject.getVariables();
 
-                assert.deepStrictEqual(variables, ['CURLIB', 'OBJLIB', 'lib3', 'lib4', 'lib1', 'lib2', 'path1', 'path2', 'valueA']);
+                assert.deepStrictEqual(variables, ['CURLIB', 'OBJLIB', 'lib3', 'lib4', 'lib1', 'lib2', 'path1', 'path2', 'valueA', 'DTALIB']);
             }
         },
         {

--- a/src/testing/suites/iProject.ts
+++ b/src/testing/suites/iProject.ts
@@ -8,7 +8,7 @@ import { TextEncoder } from "util";
 import { workspace } from "vscode";
 import { TestSuite } from "..";
 import { getDeployTools, getInstance } from "../../ibmi";
-import { ProjectFileType } from "../../iproject";
+import { ProjectFileType, escArray, escQuotes } from "../../iproject";
 import { ProjectManager } from "../../projectManager";
 import { LibraryType } from "../../views/projectExplorer/library";
 import { iProjectMock, ibmiJsonMock } from "../constants";
@@ -691,6 +691,35 @@ export const iProjectSuite: TestSuite = {
                 const deployLocation = iProject.getDeployLocation();
 
                 assert.strictEqual(deployLocation, deployLocation);
+            }
+        },
+        {
+            name: `Test escapeQuotes`, test: async () => {
+                const escapedStr = escQuotes('"abc"');
+                assert.strictEqual(escapedStr, '\\"abc\\"');
+
+                // Now test escArray()
+                const arrayStr   = ['abc', '\"def\"',   'ghi', '\"@#$\"'];
+                const escapedArr = ['abc', '\\"def\\"', 'ghi', '\\"@#$\\"'];
+                assert.deepEqual(escArray(arrayStr), escapedArr);
+            }
+        },
+        {
+            name: `Test calcUpdateLibraryListCommand`, test: async () => {
+                const iProject = ProjectManager.getProjects()[0];
+                const ibmi = getInstance();
+                const state = await iProject.getState();
+                if (!state) {assert.fail("No iproj state found!");}
+                const command = await iProject.calcUpdateLibraryListCommand(ibmi!, state!);
+                if (!command){assert.fail('LIBL command calculation failed!');}
+                assert.strictEqual(command,'liblist -d TDD_ER RPGUNIT QTEMP ; liblist -c QGPL ; liblist -a QSYSINC QTEMP RPGUNIT TDD_ER SYSTOOLS ; liblist');
+
+                // iProject.setCurrentLibrary('"abcdefg"');
+                // const state2 = await iProject.getState();
+                // if (!state2) {assert.fail("No iproj state2 found!");}
+                // const command2 = await iProject.calcUpdateLibraryListCommand(ibmi!, state2!);
+                // if (!command2){assert.fail('LIBL command2 calculation failed!');}
+                // assert.strictEqual(command2,'liblist -d TDD_ER RPGUNIT QTEMP ; liblist -c QGPL ; liblist -a QSYSINC QTEMP RPGUNIT TDD_ER SYSTOOLS ; liblist');
             }
         }
     ]

--- a/src/testing/suites/projectExplorerTreeItem.ts
+++ b/src/testing/suites/projectExplorerTreeItem.ts
@@ -252,7 +252,10 @@ export const projectExplorerTreeItemSuite: TestSuite = {
                         attribute: 'PF',
                         text: 'DATA BASE FILE FOR C INCLUDES',
                         sourceFile: true,
-                        memberCount: 1088
+                        CCSID: 37,
+                        created_by: '*IBM',
+                        owner: 'QSYS',
+                        sourceLength: 92
                     }
                 });
             }
@@ -305,7 +308,11 @@ export const projectExplorerTreeItemSuite: TestSuite = {
                         attribute: 'PROD',
                         text: 'General Purpose Library',
                         sourceFile: false,
-                        memberCount: undefined
+                        memberCount: undefined,
+                        CCSID: undefined,
+                        created_by: "*IBM",
+                        owner: 'QSYS',
+                        sourceLength: undefined
                     }
                 });
                 assertTreeItem(children[2], {
@@ -318,7 +325,11 @@ export const projectExplorerTreeItemSuite: TestSuite = {
                         attribute: 'PROD',
                         text: 'System Library for DB2',
                         sourceFile: false,
-                        memberCount: undefined
+                        memberCount: undefined,
+                        CCSID: undefined,
+                        created_by: "*IBM",
+                        owner: 'QSYS',
+                        sourceLength: undefined
                     }
                 });
                 assertTreeItem(children[3], {
@@ -335,7 +346,11 @@ export const projectExplorerTreeItemSuite: TestSuite = {
                         attribute: 'PROD',
                         text: '',
                         sourceFile: false,
-                        memberCount: undefined
+                        memberCount: undefined,
+                        CCSID: undefined,
+                        created_by: "QLPINSTALL",
+                        owner: 'QSYS',
+                        sourceLength: undefined
                     }
                 });
                 assertTreeItem(children[5], {
@@ -431,7 +446,19 @@ export const projectExplorerTreeItemSuite: TestSuite = {
 
 function assertTreeItem(treeItem: ProjectExplorerTreeItem, attributes: { [key: string]: any }) {
     for (const [key, value] of (Object.entries(attributes))) {
-        assert.deepStrictEqual(treeItem[key as keyof TreeItem], value);
+        if (key === 'libraryInfo' ||
+            key === 'objectFileInfo') {
+            assertIBMiObject(treeItem[key as keyof TreeItem] as { [key: string]: any }, value);
+        } else {
+            assert.deepStrictEqual(treeItem[key as keyof TreeItem], value);
+        }
+    }
+}
+ // Test IBMiObject but ignore timesctamps and size that will vary           
+function assertIBMiObject(actual: { [key: string]: any }, expected: { [key: string]: any }) {
+      for (const [key, value] of (Object.entries(expected))) {
+        if (key in ['changed', 'created', 'size', 'memberCount']) {continue;}
+        assert.deepStrictEqual(actual[key], value);
     }
 }
 

--- a/src/testing/suites/projectManager.ts
+++ b/src/testing/suites/projectManager.ts
@@ -171,8 +171,9 @@ export const projectManagerSuite: TestSuite = {
                 const projectTreeItem = new Project(workspaceFolder, { description: 'SAMPLE PROJECT' });
                 const children = await projectTreeItem.getChildren();
                 Project.callBack = [];
+                const last = children.length-1;
 
-                assert.strictEqual(children[5].label, 'Test Tree Item');
+                assert.strictEqual(children[last].label, 'Test Tree Item');
             }
         }
     ]

--- a/src/testing/suites/utilTest.ts
+++ b/src/testing/suites/utilTest.ts
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright IBM Corp. 2023
+ */
+
+import * as assert from "assert";
+import { TestSuite } from "..";
+import { escapeArray, isEscapeQuoted, stripEscapeFromQuotes, isQuoted, escapeQuoted } from "../../util";
+
+
+export const utilSuite: TestSuite = {
+    name: `Util Tests`,
+    tests: [
+        {
+            name: `Test escQuotes and escArray`, test: async () => {
+                assert.strictEqual(escapeQuoted('"abc"'), '\\"abc\\"');
+                assert.strictEqual(escapeQuoted('a"b'),   'a"b');
+                assert.strictEqual(escapeQuoted('a"'),    'a"');
+                assert.strictEqual(escapeQuoted('"b'),    '"b');
+                assert.strictEqual(escapeQuoted(''),      '');
+                // Now test escArray()
+                const arrayStr   = ['abc', '\"def\"', '', 'ghi', '\"@#$\"'];
+                const escapedArr = ['abc', '\\"def\\"', '', 'ghi', '\\"@#$\\"'];
+                assert.deepEqual(escapeArray(arrayStr), escapedArr);
+            },
+        },
+        {
+            name: `Test isQuoted`, test: async () => {
+                assert.equal(isQuoted('\"abc\"'),  true);
+                assert.equal(isQuoted('"abc"'),    true);
+                assert.equal(isQuoted('abc'),      false);
+                assert.equal(isQuoted(''),         false);
+                assert.equal(isQuoted('"abc'),     false);
+                assert.equal(isQuoted('abc"'),     false);
+                assert.equal(isQuoted('\\"abc\\"'),false);
+            },
+        },
+        {
+            name: `Test stripEscapeFromQuotes`, test: async () => {
+                assert.equal('\"abc\"', stripEscapeFromQuotes('\"abc\"'));
+                assert.equal('"abc"', stripEscapeFromQuotes('"abc"'));
+                assert.equal('abc', stripEscapeFromQuotes('abc'));
+                assert.equal('\\"abc"', stripEscapeFromQuotes('\\"abc"'));
+                assert.equal('abc\\"', stripEscapeFromQuotes('abc\\"'));
+                assert.equal('"abc"', stripEscapeFromQuotes('\\"abc\\"'));
+                assert.equal('\\"', stripEscapeFromQuotes('\\"'));
+                assert.equal('""', stripEscapeFromQuotes('\\"\\"'));
+                assert.equal('', stripEscapeFromQuotes(''));
+            },
+        },
+        {
+            name: `Test escapeQuoted`, test: async () => {
+                assert.equal(escapeQuoted('\"abc\"'),       '\\"abc\\"');
+                assert.equal(escapeQuoted('"abc"'),         '\\"abc\\"');
+                assert.equal(escapeQuoted('abc'),           'abc');
+                assert.equal(escapeQuoted(''),              '');
+                assert.equal(escapeQuoted('\\"abc'),        '\\"abc');
+                assert.equal(escapeQuoted('abc\\"'),        'abc\\"');
+                assert.equal(escapeQuoted('\\"abc\\"'),     '\\"abc\\"');
+            },
+        },
+        {
+            name: `Test isEscapeQuoted`, test: async () => {
+                assert.equal(false, isEscapeQuoted('\"abc\"'));
+                assert.equal(false, isEscapeQuoted('"abc"'));
+                assert.equal(false, isEscapeQuoted('abc'));
+                assert.equal(false, isEscapeQuoted('\\"abc'));
+                assert.equal(false, isEscapeQuoted('abc\\"'));
+                assert.equal(true, isEscapeQuoted('\\"abc\\"'));
+            },
+        }
+        
+    ]
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright IBM Corp. 2024
+ */
+/**
+ * The escQuoted function takes in a string as an argument and 
+ * returns a new string with any leading and trailing 
+ * double quotes escaped with a backslash.
+ * 
+ * @param input : string - The string to escape quotes in. 
+ * 
+ * @returnS A new string with any leading and trailing
+ *         double quotes escaped with a backslash.
+ * 
+ * Exceptions and Edge Cases
+ * If the input string contains unescaped double quotes, they will be escaped 
+ * even if they are not at the beginning or end of the string. 
+ * For example, the input string "hello" would be escaped to \\"hello\\".
+ */
+export function escapeQuoted(input: string): string
+{
+    if(isQuoted(input)) {
+        return '\\'+input.substring(0,input.length-1)+'\\"';
+    }
+    return input;
+}
+/**
+ * Checks if a string starts and ends with backslash-escaped double quotes.
+ * 
+ * @param value The string to check.
+ * 
+ * @returns Returns true if the string starts and ends with 
+ *          backslash-escaped double quotes, false otherwise.
+ *
+ * Exceptions and Edge Cases
+ * If the input string is not a valid string, the function may throw a TypeError or similar. 
+   */
+export function escapeArray(oldArray: string[]): string[] {
+    var newArray = oldArray.map(function (e) {
+      e = escapeQuoted(e);
+      return e;
+    });
+    return newArray;
+  }
+  export function isEscapeQuoted(value: string): boolean {
+    return  (value.startsWith('\\"') && value.endsWith('\\"') && value.length >= 4);
+  }
+  /**
+   * Checks if a string starts and ends with double quotes.
+   * 
+   * @param value The string to check.
+   * 
+   * @returns Returns true if the string starts and ends with double quotes, false otherwise.
+   *
+   * Exceptions and Edge Cases
+   * If the input string is not a valid string, the function may throw a TypeError or similar. 
+   */
+  export function isQuoted(value: string): boolean {
+    return  (value.startsWith('\"') && value.endsWith('\"'));
+  }
+  export function stripEscapeFromQuotes(value: string): string {
+    if(isEscapeQuoted(value)) {
+        return  '"'+value.substring(2,value.length-2)+'"';
+    } else {
+        return value;
+    }
+  } 


### PR DESCRIPTION
Fixes issue 377
Adding libraries with quoted names did not work either as direct values or as variable values.

Utility method to escape and unescape these quotes were added to new util module.   These methods were thoroughly tested.
<img width="307" alt="image" src="https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11184579/681fad4a-3244-4504-9c80-92c82d11c6d5">

Variable values were escaped before being persisted into .env and unescaped on reading from the same.  This was neccessary because the parser stripped the unescaped double quotes.

Library names had to be unescaped to pass the validation API
But they had to be escaped when calling the liblist command because the PASE shell would strip them before doing the call.

The calculation of the LIBL was factored out and tested and will assist for fixing the issue with resolving included members based on the LIBL.
<img width="301" alt="image" src="https://github.com/IBM/vscode-ibmi-projectexplorer/assets/11184579/473e5ea9-db2f-48f4-8444-02a1830ca586">
