### PR TITLE
fix source orbit enablement for Migrate Source

### DIFF
--- a/src/sourceOrbit.ts
+++ b/src/sourceOrbit.ts
@@ -16,5 +16,5 @@ export async function sourceOrbitEnabled(): Promise<boolean> {
   }
 
   // Source Orbit extension does not have an accessible API. We just want to know if we have it installed or not.
-  return (baseExtension && baseExtension.isActive && baseExtension.exports ? true : false);
+  return (baseExtension && baseExtension.isActive ? true : false);
 }


### PR DESCRIPTION
Migrate Source was missing the `Clean up` tab because the sourceOrbitEnabled() was returning false.

This has been fixed.