### PR TITLE
Make version optional in .ibmi.json

### DIFF
--- a/schema/ibmi.schema.json
+++ b/schema/ibmi.schema.json
@@ -33,7 +33,6 @@
         }
     },
     "required": [
-        "version",
         "build"
     ]
 }


### PR DESCRIPTION
For migrated source by bob, this is not generated and then it is flagged as an error>

Once there is a change to the json schema we will require it and assume the missing version means initial version.