### PR TITLE
Update types for Code for i 2.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "jsonschema": "^1.4.1"
       },
       "devDependencies": {
-        "@halcyontech/vscode-ibmi-types": "^2.9.0",
+        "@halcyontech/vscode-ibmi-types": "^2.10.1",
         "@types/node": "20.x",
         "@types/tar": "^6.1.13",
         "@types/vscode": "^1.75.0",
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/@halcyontech/vscode-ibmi-types": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.9.0.tgz",
-      "integrity": "sha512-LISN3ToD6im7eB5q0UuuZmVEwSE5cn3RR7HV1/VMW7qfmlqLYEllddV5LecDmmRix+f3ZzP6CURolFserhk3dg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.10.1.tgz",
+      "integrity": "sha512-6S4vfMTpW8KkwpMJ2qPeNKL3S4GgmghUgZhiMVKlmwShYrnQ+cUjstYmKpB+EDxKbYOSRsd16e1EiF9qoyYaGw==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4689,9 +4689,9 @@
       "dev": true
     },
     "@halcyontech/vscode-ibmi-types": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.9.0.tgz",
-      "integrity": "sha512-LISN3ToD6im7eB5q0UuuZmVEwSE5cn3RR7HV1/VMW7qfmlqLYEllddV5LecDmmRix+f3ZzP6CURolFserhk3dg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.10.1.tgz",
+      "integrity": "sha512-6S4vfMTpW8KkwpMJ2qPeNKL3S4GgmghUgZhiMVKlmwShYrnQ+cUjstYmKpB+EDxKbYOSRsd16e1EiF9qoyYaGw==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -1531,7 +1531,7 @@
     "types": "npx -p typescript tsc ./src/extension.ts --excludeDirectories ./src/testing --declaration --allowJs --emitDeclarationOnly --outDir types --esModuleInterop -t es2020 --moduleResolution node"
   },
   "devDependencies": {
-    "@halcyontech/vscode-ibmi-types": "^2.9.0",
+    "@halcyontech/vscode-ibmi-types": "^2.10.1",
     "@types/node": "20.x",
     "@types/tar": "^6.1.13",
     "@types/vscode": "^1.75.0",

--- a/src/testing/suites/projectExplorerTreeItem.ts
+++ b/src/testing/suites/projectExplorerTreeItem.ts
@@ -3,15 +3,15 @@
  */
 
 import * as assert from "assert";
-import { TestSuite } from "..";
-import { ProjectManager } from "../../projectManager";
 import * as path from "path";
 import { TreeItem, Uri, extensions, workspace } from "vscode";
-import { IBMiProjectExplorer } from "../../ibmiProjectExplorer";
-import ProjectExplorer from "../../views/projectExplorer";
+import { TestSuite } from "..";
 import { getInstance } from "../../ibmi";
-import { ProjectExplorerTreeItem } from "../../views/projectExplorer/projectExplorerTreeItem";
+import { IBMiProjectExplorer } from "../../ibmiProjectExplorer";
+import { ProjectManager } from "../../projectManager";
+import ProjectExplorer from "../../views/projectExplorer";
 import MemberFile from "../../views/projectExplorer/memberFile";
+import { ProjectExplorerTreeItem } from "../../views/projectExplorer/projectExplorerTreeItem";
 import SourceDirectory from "../../views/projectExplorer/sourceDirectory";
 import { iProjectMock } from "../constants";
 
@@ -252,7 +252,6 @@ export const projectExplorerTreeItemSuite: TestSuite = {
                         attribute: 'PF',
                         text: 'DATA BASE FILE FOR C INCLUDES',
                         sourceFile: true,
-                        CCSID: 37,
                         created_by: '*IBM',
                         owner: 'QSYS',
                         sourceLength: 92
@@ -308,8 +307,6 @@ export const projectExplorerTreeItemSuite: TestSuite = {
                         attribute: 'PROD',
                         text: 'General Purpose Library',
                         sourceFile: false,
-                        memberCount: undefined,
-                        CCSID: undefined,
                         created_by: "*IBM",
                         owner: 'QSYS',
                         sourceLength: undefined
@@ -325,8 +322,6 @@ export const projectExplorerTreeItemSuite: TestSuite = {
                         attribute: 'PROD',
                         text: 'System Library for DB2',
                         sourceFile: false,
-                        memberCount: undefined,
-                        CCSID: undefined,
                         created_by: "*IBM",
                         owner: 'QSYS',
                         sourceLength: undefined
@@ -346,8 +341,6 @@ export const projectExplorerTreeItemSuite: TestSuite = {
                         attribute: 'PROD',
                         text: '',
                         sourceFile: false,
-                        memberCount: undefined,
-                        CCSID: undefined,
                         created_by: "QLPINSTALL",
                         owner: 'QSYS',
                         sourceLength: undefined
@@ -457,7 +450,7 @@ function assertTreeItem(treeItem: ProjectExplorerTreeItem, attributes: { [key: s
  // Test IBMiObject but ignore timesctamps and size that will vary           
 function assertIBMiObject(actual: { [key: string]: any }, expected: { [key: string]: any }) {
       for (const [key, value] of (Object.entries(expected))) {
-        if (key in ['changed', 'created', 'size', 'memberCount']) {continue;}
+        if (key in ['changed', 'created', 'size']) {continue;}
         assert.deepStrictEqual(actual[key], value);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/IBM/vscode-ibmi-projectexplorer/issues/449#issuecomment-2096993574

This PR bumps the Code for IBM i types to `2.10.1` and updates the test to remove the fields that were removed from `IBMiObject`.
It has no impact on the rest of the extension.