### PR TITLE
Publish to Open VSX before the marketplace

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,15 +31,15 @@ jobs:
           npm install
           npm install -g vsce ovsx
 
-      - name: Publish to Marketplace
-        run: vsce publish -p $PUBLISHER_TOKEN
-        env:
-          PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
-
       - name: Publish to Open VSX
         run: npx ovsx publish -p $OPENVSX_TOKEN
         env:
           OPENVSX_TOKEN: ${{ secrets.OPENVSX_TOKEN }}
+
+      - name: Publish to Marketplace
+        run: vsce publish -p $PUBLISHER_TOKEN
+        env:
+          PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
 
       - name: Generate Types
         continue-on-error: true


### PR DESCRIPTION
Publishing to Open VSX catches more issues (translation errors), so it is better to run it first