### PR TITLE
Add getting started walkthrough

### DIFF
--- a/docs/pages/jobLog/viewing-job-logs.md
+++ b/docs/pages/jobLog/viewing-job-logs.md
@@ -9,38 +9,38 @@ Project Explorer provides a view in the `IBM i Job Log` panel to display all of 
 ### Project level
 The top level of this tree is the project name with the project description as its details.  This allows the job logs of multiple projects to be shown in this view.  Only the latest build is persisted in the project, but the other jobs are kept in memory until the workspace is restarted or the `Clear Previous Job Logs` action on the project is run.
 
-<img src="/assets/jl_action_clear.png" width="300">
+<img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_action_clear.png?raw=true" width="400">
 
 The `Show Job Log` action, which is also available inline, will load the joblog.json file with the raw data into the editor.  This might be useful for searching, etc.
 
-<img src="/assets/jl_action_show_joblog_inline.png" width="600">
+<img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_action_show_joblog_inline.png?raw=true" width="600">
 
 ### Job log level
 The next level is the timestamp when the build or compile was run and represents all the command run for that particular build.
 The commands can be toggled via the inline action to show all executed commands or only those that failed.
 
-<img src="/assets/jl_action_show_failed.png" width="500">
+<img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_action_show_failed.png?raw=true" width="500">
 
 If the action above is selected, all successful commands are filtered out so that you can focus on the failing ones.  This can be very useful when lots of objects are being built.
 
-<img src="/assets/jl_action_show_all.png" width="500">
+<img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_action_show_all.png?raw=true" width="500">
 
 To help zero in on the problem, there is also an action to filter the messages, so that you can set the minimum severity of messages you would like to see.
 
-<img src="/assets/jl_action_filter_inline.png" width="500">
+<img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_action_filter_inline.png?raw=true" width="500">
 
 In this example we select the minimum severity of the messages to be 10.
 
-<img src="/assets/jl_select_severity.png" width="500">
+<img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_select_severity.png?raw=true" width="500">
 
 As a result we see all of the information messages being filtered out so we can see that actual failures.
 
- <img src="/assets/jl_high_sev_messages.png" width="500">
+ <img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_high_sev_messages.png?raw=true" width="500">
 
 ### Object level
 The children of a job log are all the ILE objects being built.  The description is the source in the IFS that is being compiled into that object.
 
- <img src="/assets/jl_actions_object.png" width="600">
+ <img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_actions_object.png?raw=true" width="600">
 
 The actions available on the object, both in the context menu and the inline menu include `Copy` and `Show Object Build Output`.  The `Copy` action copies the command into the clipboard.  This allows you to paste it into the 5250 or PASE where you can run the command in isolation.
 The `Show Object Build Output` will show the equivalent of spool file output including the compile listing and any standard error and output from PASE commands.  Note that the compile errors will also be shown in the `Problems` view but sometimes there are other reasons for a command to fail and they can be seen here.
@@ -51,12 +51,12 @@ On the next level the first item is unique. It is the compile command being run 
 
 The remaining items are the messages that were produced in the job log when executing this command.  While there are no actions on messages, the hover shows all of the message details including second level help.
 
- <img src="/assets/jl_second_level_message.png" width="500">
+ <img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/jl_second_level_message.png?raw=true" width="500">
 
 ## Where does the data come from
 Build commands such as BOB (https://github.com/IBM/ibmi-bob) and ARCAD generate a file named `.logs/joblog.json`. They also generate text files in the same directory with names like `target_object.splf` that contain the PASE standard out or spool file equivalent for each command, including the compile listing.  These files are copied to the `.logs` directory in the project root.
 
-<img src="/assets/joblog_files.png" width="300">
+<img src="https://github.com/IBM/vscode-ibmi-projectexplorer/blob/main/docs/assets/joblog_files.png?raw=true" width="300">
 
 This copy process is automatic when invoking build or compile action for `IBM i Project Explorer` projects. For `Code for IBM i` actions the downloading of these files can be configured by the `postDownload` attribute in the `actions.json`  file.  The `.evfevent` directory specified here is necessary to get the compiler errors in the `Problems` view.
 

--- a/docs/pages/projectExplorer/create-new-project.md
+++ b/docs/pages/projectExplorer/create-new-project.md
@@ -1,19 +1,9 @@
 # Create New Project
 
-To get starting with an IBM i project, create a folder and open it in the workspace. For a workspace folder to be treated as an IBM i project, it must contain an `iproj.json` file. This can be done from the **Project Explorer** view using the **Create iproj.json** action. This will prompt you to enter a description for the project and then create the file.
+To get starting with an IBM i project, create a folder and open it in the workspace. For a workspace folder to be treated as an IBM i project, it must contain an `iproj.json` file. This can be done from the **Project Explorer** view using the **Create iproj.json** action. This will prompt you to enter a description for the project and then create the file. Upon creating this file, you can now get started with development. To get started with working on source code locally in your project from source physical files in QSYS, check out the documentation on how to [migrate source](pages/projectExplorer/migrate-source.md). To work with multiple projects at the same time, add each project as a separate workspace folder.
 
 ![Create iproj.json](../../assets/ProjectExplorer_01.png)
-
-Upon creating this file, you can now get started with development. Refer to the subsequent pages on how to accomplish different tasks or manage different aspects of the project.
-
-> [!NOTE]
->
-> Note that to work with multiple projects at the same time, add each project as a separate workspace folder.
 
 In the scenario you ever find that your project's `iproj.json` file is corrupt, hover on the project in the **Project Explorer** view to see if there are any errors present. If there are errors, use the `Open iproj.json` action and refer to the **Problems** view to see how you can resolve them.
 
 ![Create iproj.json](../../assets/ProjectExplorer_02.png)
-
-> [!TIP]
->
-> To get started with working on source code locally in your project from source physical files in QSYS, check out the documentation on how to [migrate source](pages/projectExplorer/migrate-source.md).

--- a/package.json
+++ b/package.json
@@ -41,6 +41,47 @@
   ],
   "l10n": "./l10n",
   "contributes": {
+    "walkthroughs": [
+      {
+        "id": "projectExplorer.gettingStarted",
+        "title": "%walkthroughs.gettingStarted.title%",
+        "description": "%walkthroughs.gettingStarted.description%",
+        "steps": [
+          {
+            "id": "createNewProject",
+            "title": "%walkthroughs.createNewProject.title%",
+            "description": "%walkthroughs.createNewProject.description%",
+            "media": {
+              "markdown": "docs/pages/projectExplorer/create-new-project.md"
+            }
+          },
+          {
+            "id": "connectToARemoteSystem",
+            "title": "%walkthroughs.connectToARemoteSystem.title%",
+            "description": "%walkthroughs.connectToARemoteSystem.description%",
+            "media": {
+              "markdown": "docs/pages/projectExplorer/connect-to-a-remote-system.md"
+            }
+          },
+          {
+            "id": "sourceAndDeployment",
+            "title": "%walkthroughs.sourceAndDeployment.title%",
+            "description": "%walkthroughs.sourceAndDeployment.description%",
+            "media": {
+              "markdown": "docs/pages/projectExplorer/source-and-deployment.md"
+            }
+          },
+          {
+            "id": "runBuildsCompilesAndActions",
+            "title": "%walkthroughs.runBuildsCompilesAndActions.title%",
+            "description": "%walkthroughs.runBuildsCompilesAndActions.description%",
+            "media": {
+              "markdown": "docs/pages/projectExplorer/run-builds-compiles-and-actions.md"
+            }
+          }
+        ]
+      }
+    ],
     "views": {
       "explorer": [
         {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
         "id": "projectExplorer.gettingStarted",
         "title": "%walkthroughs.gettingStarted.title%",
         "description": "%walkthroughs.gettingStarted.description%",
+        "featuredFor": [
+          "iproj.json",
+          ".ibmi.json",
+          "joblog.json"
+        ],
         "steps": [
           {
             "id": "createNewProject",

--- a/package.nls.json
+++ b/package.nls.json
@@ -101,5 +101,15 @@
   "viewsWelcome.jobLog.noWorkspace": "No workspace folder opened",
   "viewsWelcome.jobLog.scanning": "Scanning for projects...",
   "viewsWelcome.projectExplorer.noWorkspace": "No workspace folder opened",
-  "viewsWelcome.projectExplorer.scanning": "Scanning for projects..."
+  "viewsWelcome.projectExplorer.scanning": "Scanning for projects...",
+  "walkthroughs.gettingStarted.title": "Get Started with IBM i Project Explorer",
+  "walkthroughs.gettingStarted.description": "Get started with what you need to develop IBM i applications using IBM i Project Explorer",
+  "walkthroughs.createNewProject.title": "Create New Project",
+  "walkthroughs.createNewProject.description": "Create an IBM i project by opening a workspace folder with an iproj.json file or migrate your source from QSYS.",
+  "walkthroughs.connectToARemoteSystem.title": "Connect to a Remote System",
+  "walkthroughs.connectToARemoteSystem.description": "Connect to an IBM i using the Connections browser.",
+  "walkthroughs.sourceAndDeployment.title": "Source and Deployment",
+  "walkthroughs.sourceAndDeployment.description": "Visualize and deploy your local source files to your deploy location in the IFS.",
+  "walkthroughs.runBuildsCompilesAndActions.title": "Run Builds, Compiles, and Actions",
+  "walkthroughs.runBuildsCompilesAndActions.description": "Configure how your project will be built and compiled."
 }


### PR DESCRIPTION
This PR adds a walkthrough that points to the first 4 markdown pages under the Project Explorer heading in our docs.

Also should fix some issues with images using `<img>` tags not rendering.