### PR TITLE
Fix error handling of invalid `iproj.json` file

### DIFF
--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -15,7 +15,7 @@ import { IProjectT } from "./iProjectT";
 import { getDeployTools, getInstance } from "./ibmi";
 import { IBMiJsonT } from "./ibmiJsonT";
 import { JobLogInfo } from "./jobLog";
-import { ProjectManager } from "./projectManager";
+import { ProjectExplorerSchemaId, ProjectManager } from "./projectManager";
 import { RingBuffer } from "./views/jobLog/RingBuffer";
 import { LibraryType } from "./views/projectExplorer/library";
 import Instance from "@halcyontech/vscode-ibmi-types/api/Instance";
@@ -278,22 +278,23 @@ export class IProject {
 
     try {
       let content = (await workspace.fs.readFile(this.getProjectFileUri('iproj.json'))).toString();
-      if (content === '') {
-        content = '{}';
-      }
-      unresolvedState = JSON.parse(content, (key, value) => {
-        if (key === 'extensions') {
-          return new Map(Object.entries(value));
+
+      try {
+        unresolvedState = JSON.parse(content, (key, value) => {
+          if (key === 'extensions') {
+            return new Map(Object.entries(value));
+          }
+
+          return value;
+        });
+      } catch (e) {
+        if (content.trim() === '') {
+          unresolvedState = {};
         }
+      }
 
-        return value;
-      });
-
-      const validator = ProjectManager.getValidator();
-      const schema = validator.schemas['/iproj'];
-      const validatorResult = validator.validate(unresolvedState || content, schema);
-
-      if (validatorResult && validatorResult.errors.length > 0 && content.trim() !== '') {
+      const validatorResult = ProjectManager.validateSchema(ProjectExplorerSchemaId.iproj, unresolvedState || content);
+      if (validatorResult && validatorResult.errors.length > 0) {
         this.validatorResult = validatorResult;
         return undefined;
       } else {

--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -277,7 +277,7 @@ export class IProject {
     let unresolvedState: IProjectT | undefined;
 
     try {
-      let content = (await workspace.fs.readFile(this.getProjectFileUri('iproj.json'))).toString();
+      const content = (await workspace.fs.readFile(this.getProjectFileUri('iproj.json'))).toString();
 
       try {
         unresolvedState = JSON.parse(content, (key, value) => {

--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -277,7 +277,10 @@ export class IProject {
     let unresolvedState: IProjectT | undefined;
 
     try {
-      const content = (await workspace.fs.readFile(this.getProjectFileUri('iproj.json'))).toString();
+      let content = (await workspace.fs.readFile(this.getProjectFileUri('iproj.json'))).toString();
+      if (content === '') {
+        content = '{}';
+      }
       unresolvedState = JSON.parse(content, (key, value) => {
         if (key === 'extensions') {
           return new Map(Object.entries(value));


### PR DESCRIPTION
**Changes**
- Fix handling of empty `iproj.json` file so library list shows up correctly
- Update logic for registering schema validators
- Fix error handling of invalid `iproj.json` file so schema validator shows an error:
  ![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/32170854/f55ee362-683d-44bb-ace5-c1d8b01891f2)
