### PR TITLE
Fix syncing of `LIBL` and `CURLIB`

### DIFF
--- a/src/fileWatcher.ts
+++ b/src/fileWatcher.ts
@@ -64,7 +64,7 @@ export namespace ProjectFileWatcher {
             } else if (uri.fsPath.endsWith('.ibmi.json')) {
                 iProject.setBuildMap(undefined);
             } else if (uri.fsPath.endsWith('.env')) {
-                // IF the .env was updated only for keeping track of the LIBL state for other
+                // If the .env was updated only for keeping track of the LIBL state for other
                 // extensions, then we don't want to refresh the UI and state
                 if (iProject.wasLiblVarsUpdated()) {
                     return;
@@ -75,7 +75,7 @@ export namespace ProjectFileWatcher {
             } else {
                 const projectTreeItem = projectExplorer.getProjectTreeItem(iProject);
 
-                if (projectTreeItem && projectTreeItem.children && 
+                if (projectTreeItem && projectTreeItem.children &&
                     projectTreeItem.children.length > 0 && projectTreeItem.children[0] instanceof Source) {
                     elementToRefresh = projectTreeItem.children[0];
                 }

--- a/src/iproject.ts
+++ b/src/iproject.ts
@@ -4,7 +4,6 @@
 
 import { Action, CommandResult, DeploymentMethod, DeploymentParameters, IBMiObject } from "@halcyontech/vscode-ibmi-types";
 import * as dotenv from 'dotenv';
-import { isEscapeQuoted, stripEscapeFromQuotes, escapeQuoted, escapeArray } from "./util";
 import { ValidatorResult } from "jsonschema";
 import * as path from "path";
 import { parse } from "parse-gitignore";
@@ -19,6 +18,7 @@ import { ProjectExplorerSchemaId, ProjectManager } from "./projectManager";
 import { RingBuffer } from "./views/jobLog/RingBuffer";
 import { LibraryType } from "./views/projectExplorer/library";
 import Instance from "@halcyontech/vscode-ibmi-types/api/Instance";
+import { util } from "./util";
 
 /**
  * Represents the default variable for a project's current library.
@@ -260,7 +260,7 @@ export class IProject {
    * represents the current state is invalid and will be automatically updated
    * whenever it is retrieved again.
    * 
-   * @param state The project state to set or `undefined`.
+   * @param state The resolved project state to set or `undefined`.
    */
   public setState(state: IProjectT | undefined) {
     this.state = state;
@@ -867,9 +867,14 @@ export class IProject {
     }
     return this.libraryList;
   }
-  /*
-   * Generate the commands to update the library list using pase 'liblist' commmands and execute them
-   * Return the result of those commands
+
+  /**
+   * Generate the commands to update the library list using pase `liblist` commands,
+   * execute them and return the result of those commands.
+   * 
+   * @param ibmi The Code for IBM i `Instance`.
+   * @param state The resolved project state.
+   * @returns The liblist command result.
    */
   public async updateLibraryListOnIbmi(ibmi: Instance, state: IProjectT): Promise<CommandResult> {
     let buildLibraryListCommand = await this.calcUpdateLibraryListCommand(ibmi, state);
@@ -881,10 +886,11 @@ export class IProject {
   }
 
   /**
-   * Calculate the commands to replace USRLIBL and set CURLIB within library list
-   * @param ibmi connection
-   * @param state resolved iproj.json state
-   * @returns command
+   * Calculate the commands to replace `USRLIBL` and set `CURLIB` within library list.
+   * 
+   * @param ibmi The Code for IBM i `Instance`.
+   * @param state The resolved project state.
+   * @returns The liblist command.
    */
   public async calcUpdateLibraryListCommand(ibmi: Instance, state: IProjectT): Promise<string> {
     const defaultUserLibraries = ibmi.getConnection().defaultUserLibraries;
@@ -909,11 +915,11 @@ export class IProject {
     }
 
     // Retrieve library list
-    // Note quoted library names need to be escaped in order for the comman shell not tointerpret them but pass alon to theliblist command
+    // Note quoted library names need to be escaped in order for the command shell not to interpret them but pass along to the liblist command
     let buildLibraryListCommand = [
       defaultUserLibraries ? `liblist -d ${defaultUserLibraries.join(` `)}` : ``,
-      state.curlib && state.curlib !== '' ? `liblist -c ${escapeQuoted(state.curlib)}` : ``,
-      userLibrariesToAdd && userLibrariesToAdd.length > 0 ? `liblist -a ${escapeArray(userLibrariesToAdd).join(` `)}` : ``,
+      state.curlib && state.curlib !== '' ? `liblist -c ${util.escapeQuoted(state.curlib)}` : ``,
+      userLibrariesToAdd && userLibrariesToAdd.length > 0 ? `liblist -a ${util.escapeArray(userLibrariesToAdd).join(` `)}` : ``,
       `liblist`
     ].filter(cmd => cmd !== ``).join(` ; `);
     return buildLibraryListCommand;
@@ -1267,8 +1273,8 @@ export class IProject {
       // Now those backslashes should be removed
       for (const key in this.environmentValues) {
         const value = this.environmentValues[key];
-        if (isEscapeQuoted(value)) {
-          this.environmentValues[key] = stripEscapeFromQuotes(value);
+        if (util.isEscapeQuoted(value)) {
+          this.environmentValues[key] = util.stripEscapeFromQuotes(value);
         }
       }
     } catch (e) {
@@ -1289,7 +1295,7 @@ export class IProject {
    */
   public async updateEnvVar(variable: string, value: string) {
     const envUri = this.getProjectFileUri('.env');
-    value = escapeQuoted(value);
+    value = util.escapeQuoted(value);
     const isEnvVarUpdated = await envUpdater(envUri, { [variable]: value });
 
     if (isEnvVarUpdated) {
@@ -1307,13 +1313,12 @@ export class IProject {
   public async syncLiblVars(): Promise<boolean> {
     const env = await this.getEnv();
 
-    const curLib = await this.state?.curlib;
+    const curLib = this.state?.curlib;
     const libl = (await this.getLibraryList())?.filter(lib => lib.libraryListPortion === `USR`).map(lib => lib.libraryInfo.name).join(` `);
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     let newEnv: { LIBL?: string, CURLIB?: string } = {};
 
-    if (curLib && env.CURLIB !== curLib) {
+    if (curLib && env.CURLIB !== curLib && !curLib.startsWith('&')) {
       newEnv.CURLIB = curLib;
     }
 

--- a/src/testing/suites/projectExplorerTreeItem.ts
+++ b/src/testing/suites/projectExplorerTreeItem.ts
@@ -14,6 +14,8 @@ import MemberFile from "../../views/projectExplorer/memberFile";
 import { ProjectExplorerTreeItem } from "../../views/projectExplorer/projectExplorerTreeItem";
 import SourceDirectory from "../../views/projectExplorer/sourceDirectory";
 import { iProjectMock } from "../constants";
+import { testUtil } from "../testUtil";
+import { IBMiObject } from "@halcyontech/vscode-ibmi-types";
 
 class File {
     readonly name: string;
@@ -439,19 +441,11 @@ export const projectExplorerTreeItemSuite: TestSuite = {
 
 function assertTreeItem(treeItem: ProjectExplorerTreeItem, attributes: { [key: string]: any }) {
     for (const [key, value] of (Object.entries(attributes))) {
-        if (key === 'libraryInfo' ||
-            key === 'objectFileInfo') {
-            assertIBMiObject(treeItem[key as keyof TreeItem] as { [key: string]: any }, value);
+        if (key === 'libraryInfo' || key === 'objectFileInfo') {
+            testUtil.assertIBMiObject(treeItem[key as keyof TreeItem] as any as IBMiObject, value);
         } else {
             assert.deepStrictEqual(treeItem[key as keyof TreeItem], value);
         }
-    }
-}
- // Test IBMiObject but ignore timesctamps and size that will vary           
-function assertIBMiObject(actual: { [key: string]: any }, expected: { [key: string]: any }) {
-      for (const [key, value] of (Object.entries(expected))) {
-        if (key in ['changed', 'created', 'size']) {continue;}
-        assert.deepStrictEqual(actual[key], value);
     }
 }
 

--- a/src/testing/suites/utilTest.ts
+++ b/src/testing/suites/utilTest.ts
@@ -4,70 +4,72 @@
 
 import * as assert from "assert";
 import { TestSuite } from "..";
-import { escapeArray, isEscapeQuoted, stripEscapeFromQuotes, isQuoted, escapeQuoted } from "../../util";
-
+import { util } from "../../util";
 
 export const utilSuite: TestSuite = {
     name: `Util Tests`,
     tests: [
         {
-            name: `Test escQuotes and escArray`, test: async () => {
-                assert.strictEqual(escapeQuoted('"abc"'), '\\"abc\\"');
-                assert.strictEqual(escapeQuoted('a"b'),   'a"b');
-                assert.strictEqual(escapeQuoted('a"'),    'a"');
-                assert.strictEqual(escapeQuoted('"b'),    '"b');
-                assert.strictEqual(escapeQuoted(''),      '');
-                // Now test escArray()
-                const arrayStr   = ['abc', '\"def\"', '', 'ghi', '\"@#$\"'];
+            name: `Test escapeQuoted`, test: async () => {
+                assert.strictEqual(util.escapeQuoted('"abc"'), '\\"abc\\"');
+                assert.strictEqual(util.escapeQuoted('a"b'), 'a"b');
+                assert.strictEqual(util.escapeQuoted('a"'), 'a"');
+                assert.strictEqual(util.escapeQuoted('"b'), '"b');
+                assert.strictEqual(util.escapeQuoted(''), '');
+            },
+        },
+        {
+            name: `Test escapeArray`, test: async () => {
+                const arrayStr = ['abc', '\"def\"', '', 'ghi', '\"@#$\"'];
                 const escapedArr = ['abc', '\\"def\\"', '', 'ghi', '\\"@#$\\"'];
-                assert.deepEqual(escapeArray(arrayStr), escapedArr);
+                assert.deepEqual(util.escapeArray(arrayStr), escapedArr);
             },
         },
         {
             name: `Test isQuoted`, test: async () => {
-                assert.equal(isQuoted('\"abc\"'),  true);
-                assert.equal(isQuoted('"abc"'),    true);
-                assert.equal(isQuoted('abc'),      false);
-                assert.equal(isQuoted(''),         false);
-                assert.equal(isQuoted('"abc'),     false);
-                assert.equal(isQuoted('abc"'),     false);
-                assert.equal(isQuoted('\\"abc\\"'),false);
+                assert.equal(util.isQuoted('\"abc\"'), true);
+                assert.equal(util.isQuoted('"abc"'), true);
+                assert.equal(util.isQuoted('abc'), false);
+                assert.equal(util.isQuoted(''), false);
+                assert.equal(util.isQuoted('"abc'), false);
+                assert.equal(util.isQuoted('abc"'), false);
+                assert.equal(util.isQuoted('\\"abc\\"'), false);
             },
         },
         {
             name: `Test stripEscapeFromQuotes`, test: async () => {
-                assert.equal('\"abc\"', stripEscapeFromQuotes('\"abc\"'));
-                assert.equal('"abc"', stripEscapeFromQuotes('"abc"'));
-                assert.equal('abc', stripEscapeFromQuotes('abc'));
-                assert.equal('\\"abc"', stripEscapeFromQuotes('\\"abc"'));
-                assert.equal('abc\\"', stripEscapeFromQuotes('abc\\"'));
-                assert.equal('"abc"', stripEscapeFromQuotes('\\"abc\\"'));
-                assert.equal('\\"', stripEscapeFromQuotes('\\"'));
-                assert.equal('""', stripEscapeFromQuotes('\\"\\"'));
-                assert.equal('', stripEscapeFromQuotes(''));
+                assert.equal('\"abc\"', util.stripEscapeFromQuotes('\"abc\"'));
+                assert.equal('"abc"', util.stripEscapeFromQuotes('"abc"'));
+                assert.equal('abc', util.stripEscapeFromQuotes('abc'));
+                assert.equal('\\"abc"', util.stripEscapeFromQuotes('\\"abc"'));
+                assert.equal('abc\\"', util.stripEscapeFromQuotes('abc\\"'));
+                assert.equal('"abc"', util.stripEscapeFromQuotes('\\"abc\\"'));
+                assert.equal('\\"', util.stripEscapeFromQuotes('\\"'));
+                assert.equal('""', util.stripEscapeFromQuotes('\\"\\"'));
+                assert.equal('', util.stripEscapeFromQuotes(''));
             },
         },
         {
             name: `Test escapeQuoted`, test: async () => {
-                assert.equal(escapeQuoted('\"abc\"'),       '\\"abc\\"');
-                assert.equal(escapeQuoted('"abc"'),         '\\"abc\\"');
-                assert.equal(escapeQuoted('abc'),           'abc');
-                assert.equal(escapeQuoted(''),              '');
-                assert.equal(escapeQuoted('\\"abc'),        '\\"abc');
-                assert.equal(escapeQuoted('abc\\"'),        'abc\\"');
-                assert.equal(escapeQuoted('\\"abc\\"'),     '\\"abc\\"');
+                assert.equal(util.escapeQuoted('\"abc\"'), '\\"abc\\"');
+                assert.equal(util.escapeQuoted('"abc"'), '\\"abc\\"');
+                assert.equal(util.escapeQuoted('abc'), 'abc');
+                assert.equal(util.escapeQuoted(''), '');
+                assert.equal(util.escapeQuoted('\\"abc'), '\\"abc');
+                assert.equal(util.escapeQuoted('abc\\"'), 'abc\\"');
+                assert.equal(util.escapeQuoted('\\"abc\\"'), '\\"abc\\"');
             },
         },
         {
             name: `Test isEscapeQuoted`, test: async () => {
-                assert.equal(false, isEscapeQuoted('\"abc\"'));
-                assert.equal(false, isEscapeQuoted('"abc"'));
-                assert.equal(false, isEscapeQuoted('abc'));
-                assert.equal(false, isEscapeQuoted('\\"abc'));
-                assert.equal(false, isEscapeQuoted('abc\\"'));
-                assert.equal(true, isEscapeQuoted('\\"abc\\"'));
+                assert.equal(false, util.isEscapeQuoted('\"abc\"'));
+                assert.equal(false, util.isEscapeQuoted('"abc"'));
+                assert.equal(false, util.isEscapeQuoted('abc'));
+                assert.equal(false, util.isEscapeQuoted('\\"abc'));
+                assert.equal(false, util.isEscapeQuoted('abc\\"'));
+                assert.equal(true, util.isEscapeQuoted('\\"abc\\"'));
             },
         }
-        
+
     ]
 };

--- a/src/testing/testUtil.ts
+++ b/src/testing/testUtil.ts
@@ -1,0 +1,26 @@
+
+/*
+ * (c) Copyright IBM Corp. 2024
+ */
+
+import { IBMiObject } from "@halcyontech/vscode-ibmi-types";
+import * as assert from "assert";
+
+/**
+ * Testing utilities.
+ */
+export namespace testUtil {
+    /**
+     * Test `IBMiObject` from Code4i.
+     */
+    export function assertIBMiObject(actual: IBMiObject, expected: IBMiObject) {
+        for (const [key, value] of (Object.entries(expected))) {
+            // Ignore timestamps and size which will vary
+            if (key in ['changed', 'created', 'size']) {
+                continue;
+            }
+
+            assert.deepStrictEqual(actual[key as keyof IBMiObject], value);
+        }
+    }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,81 +3,86 @@
  */
 
 /**
- * The escapeQuoted function takes in a string as an argument and returns a
- * new string with any leading and trailing double quotes escaped with a backslash.
- * 
- * @param input The string to escape quotes in. 
- * @returns A new string with any leading and trailing double quotes escaped
- * with a backslash.
- * 
- * Exceptions and Edge Cases:
- * If the input string contains unescaped double quotes, they will be escaped even
- * if they are not at the beginning or end of the string. For example, the input
- * string "hello" would be escaped to \\"hello\\".
+ * Project explorer utilities.
  */
-export function escapeQuoted(input: string): string {
-  if (isQuoted(input)) {
-    return '\\' + input.substring(0, input.length - 1) + '\\"';
+export namespace util {
+  /**
+   * The escapeQuoted function takes in a string as an argument and returns a
+   * new string with any leading and trailing double quotes escaped with a backslash.
+   * 
+   * @param input The string to escape quotes in. 
+   * @returns A new string with any leading and trailing double quotes escaped
+   * with a backslash.
+   * 
+   * Exceptions and Edge Cases:
+   * If the input string contains unescaped double quotes, they will be escaped even
+   * if they are not at the beginning or end of the string. For example, the input
+   * string "hello" would be escaped to \\"hello\\".
+   */
+  export function escapeQuoted(input: string): string {
+    if (isQuoted(input)) {
+      return '\\' + input.substring(0, input.length - 1) + '\\"';
+    }
+
+    return input;
   }
 
-  return input;
-}
-
-/**
- * Calls the `escapeQuoted` function on each string in an array and returns
- * a new array with strings with any leading and trailing double quotes escaped
- * with a backslash.
- * 
- * @param oldArray The array of strings to escape.
- * @returns An array of new strings with any leading and trailing double quotes
- * escaped with a backslash.
- */
-export function escapeArray(oldArray: string[]): string[] {
-  return oldArray.map(function (e) {
-    return escapeQuoted(e);
-  });
-}
-
-/**
- * Checks if a string starts and ends with backslash-escaped double quotes.
- * 
- * @param value The string to check.
- * @returns Returns true if the string starts and ends with backslash-escaped
- * double quotes, false otherwise.
- *
- * Exceptions and Edge Cases:
- * If the input string is not a valid string, the function may throw a TypeError or similar. 
- */
-export function isEscapeQuoted(value: string): boolean {
-  return (value.startsWith('\\"') && value.endsWith('\\"') && value.length >= 4);
-}
-
-/**
- * Checks if a string starts and ends with double quotes.
- * 
- * @param value The string to check.
- * @returns Returns true if the string starts and ends with double quotes, false otherwise.
- *
- * Exceptions and Edge Cases:
- * If the input string is not a valid string, the function may throw a TypeError or similar. 
- */
-export function isQuoted(value: string): boolean {
-  return (value.startsWith('\"') && value.endsWith('\"'));
-}
-
-/**
- * Strips any leading and trailing double quotes escaped with a backslash.
- * 
- * @param value The string to strip.
- * @returns A new string with any leading and trailing double quotes escaped with a backslash removed.
- * 
- * Exceptions and Edge Cases:
- * If the input string is not a valid string, the function may throw a TypeError or similar. 
- */
-export function stripEscapeFromQuotes(value: string): string {
-  if (isEscapeQuoted(value)) {
-    return '"' + value.substring(2, value.length - 2) + '"';
-  } else {
-    return value;
+  /**
+   * Calls the `escapeQuoted` function on each string in an array and returns
+   * a new array with strings with any leading and trailing double quotes escaped
+   * with a backslash.
+   * 
+   * @param oldArray The array of strings to escape.
+   * @returns An array of new strings with any leading and trailing double quotes
+   * escaped with a backslash.
+   */
+  export function escapeArray(oldArray: string[]): string[] {
+    return oldArray.map(function (e) {
+      return escapeQuoted(e);
+    });
   }
-} 
+
+  /**
+   * Checks if a string starts and ends with backslash-escaped double quotes.
+   * 
+   * @param value The string to check.
+   * @returns Returns true if the string starts and ends with backslash-escaped
+   * double quotes, false otherwise.
+   *
+   * Exceptions and Edge Cases:
+   * If the input string is not a valid string, the function may throw a TypeError or similar. 
+   */
+  export function isEscapeQuoted(value: string): boolean {
+    return (value.startsWith('\\"') && value.endsWith('\\"') && value.length >= 4);
+  }
+
+  /**
+   * Checks if a string starts and ends with double quotes.
+   * 
+   * @param value The string to check.
+   * @returns Returns true if the string starts and ends with double quotes, false otherwise.
+   *
+   * Exceptions and Edge Cases:
+   * If the input string is not a valid string, the function may throw a TypeError or similar. 
+   */
+  export function isQuoted(value: string): boolean {
+    return (value.startsWith('\"') && value.endsWith('\"'));
+  }
+
+  /**
+   * Strips any leading and trailing double quotes escaped with a backslash.
+   * 
+   * @param value The string to strip.
+   * @returns A new string with any leading and trailing double quotes escaped with a backslash removed.
+   * 
+   * Exceptions and Edge Cases:
+   * If the input string is not a valid string, the function may throw a TypeError or similar. 
+   */
+  export function stripEscapeFromQuotes(value: string): string {
+    if (isEscapeQuoted(value)) {
+      return '"' + value.substring(2, value.length - 2) + '"';
+    } else {
+      return value;
+    }
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,66 +1,83 @@
 /*
  * (c) Copyright IBM Corp. 2024
  */
+
 /**
- * The escQuoted function takes in a string as an argument and 
- * returns a new string with any leading and trailing 
- * double quotes escaped with a backslash.
+ * The escapeQuoted function takes in a string as an argument and returns a
+ * new string with any leading and trailing double quotes escaped with a backslash.
  * 
- * @param input : string - The string to escape quotes in. 
+ * @param input The string to escape quotes in. 
+ * @returns A new string with any leading and trailing double quotes escaped
+ * with a backslash.
  * 
- * @returnS A new string with any leading and trailing
- *         double quotes escaped with a backslash.
- * 
- * Exceptions and Edge Cases
- * If the input string contains unescaped double quotes, they will be escaped 
- * even if they are not at the beginning or end of the string. 
- * For example, the input string "hello" would be escaped to \\"hello\\".
+ * Exceptions and Edge Cases:
+ * If the input string contains unescaped double quotes, they will be escaped even
+ * if they are not at the beginning or end of the string. For example, the input
+ * string "hello" would be escaped to \\"hello\\".
  */
-export function escapeQuoted(input: string): string
-{
-    if(isQuoted(input)) {
-        return '\\'+input.substring(0,input.length-1)+'\\"';
-    }
-    return input;
+export function escapeQuoted(input: string): string {
+  if (isQuoted(input)) {
+    return '\\' + input.substring(0, input.length - 1) + '\\"';
+  }
+
+  return input;
 }
+
+/**
+ * Calls the `escapeQuoted` function on each string in an array and returns
+ * a new array with strings with any leading and trailing double quotes escaped
+ * with a backslash.
+ * 
+ * @param oldArray The array of strings to escape.
+ * @returns An array of new strings with any leading and trailing double quotes
+ * escaped with a backslash.
+ */
+export function escapeArray(oldArray: string[]): string[] {
+  return oldArray.map(function (e) {
+    return escapeQuoted(e);
+  });
+}
+
 /**
  * Checks if a string starts and ends with backslash-escaped double quotes.
  * 
  * @param value The string to check.
- * 
- * @returns Returns true if the string starts and ends with 
- *          backslash-escaped double quotes, false otherwise.
+ * @returns Returns true if the string starts and ends with backslash-escaped
+ * double quotes, false otherwise.
  *
- * Exceptions and Edge Cases
+ * Exceptions and Edge Cases:
  * If the input string is not a valid string, the function may throw a TypeError or similar. 
-   */
-export function escapeArray(oldArray: string[]): string[] {
-    var newArray = oldArray.map(function (e) {
-      e = escapeQuoted(e);
-      return e;
-    });
-    return newArray;
+ */
+export function isEscapeQuoted(value: string): boolean {
+  return (value.startsWith('\\"') && value.endsWith('\\"') && value.length >= 4);
+}
+
+/**
+ * Checks if a string starts and ends with double quotes.
+ * 
+ * @param value The string to check.
+ * @returns Returns true if the string starts and ends with double quotes, false otherwise.
+ *
+ * Exceptions and Edge Cases:
+ * If the input string is not a valid string, the function may throw a TypeError or similar. 
+ */
+export function isQuoted(value: string): boolean {
+  return (value.startsWith('\"') && value.endsWith('\"'));
+}
+
+/**
+ * Strips any leading and trailing double quotes escaped with a backslash.
+ * 
+ * @param value The string to strip.
+ * @returns A new string with any leading and trailing double quotes escaped with a backslash removed.
+ * 
+ * Exceptions and Edge Cases:
+ * If the input string is not a valid string, the function may throw a TypeError or similar. 
+ */
+export function stripEscapeFromQuotes(value: string): string {
+  if (isEscapeQuoted(value)) {
+    return '"' + value.substring(2, value.length - 2) + '"';
+  } else {
+    return value;
   }
-  export function isEscapeQuoted(value: string): boolean {
-    return  (value.startsWith('\\"') && value.endsWith('\\"') && value.length >= 4);
-  }
-  /**
-   * Checks if a string starts and ends with double quotes.
-   * 
-   * @param value The string to check.
-   * 
-   * @returns Returns true if the string starts and ends with double quotes, false otherwise.
-   *
-   * Exceptions and Edge Cases
-   * If the input string is not a valid string, the function may throw a TypeError or similar. 
-   */
-  export function isQuoted(value: string): boolean {
-    return  (value.startsWith('\"') && value.endsWith('\"'));
-  }
-  export function stripEscapeFromQuotes(value: string): string {
-    if(isEscapeQuoted(value)) {
-        return  '"'+value.substring(2,value.length-2)+'"';
-    } else {
-        return value;
-    }
-  } 
+} 


### PR DESCRIPTION
### Changes
- Add exported namespace for `util` and `testUtil`
- Fix failing `calcUpdateLibraryListCommand` test
- Fix `CURLIB` syncing issue where `CURLIB=&CURLIB` in `.env` file
- Sync `LIBL` when connecting
- Fix project state and library list to be `undefined` when disconnecting

![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/32170854/c6ba6180-e2b1-4b02-a661-311c0fa5ed6d)
