### PR TITLE
Add build workflow to test pull requests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/vsix.yaml
+++ b/.github/workflows/vsix.yaml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v4
+        id: artifact-upload
         with:
           name: vscode-ibmi-projectexplorer-pr-build
           path: ./*.vsix
@@ -49,5 +50,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '👋  A new build is available for this PR based on ${{ github.event.pull_request.head.sha }}. Click [here](https://github.com/IBM/vscode-ibmi-projectexplorer/actions/runs/${{ github.run_id }}) to download.'
+              body: '👋  A new build is available for this PR based on ${{ github.event.pull_request.head.sha }}. Click [here](${{ steps.artifact-upload.outputs.artifact-url }}) to download.'
             })

--- a/.github/workflows/vsix.yaml
+++ b/.github/workflows/vsix.yaml
@@ -1,0 +1,53 @@
+name: Build VSIX
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    name: Build and Upload
+
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'build')
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install NPM Dependencies
+        run: |
+          npm install
+          npm install -g vsce
+
+      - name: Package
+        run: vsce package
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-ibmi-projectexplorer-pr-build
+          path: ./*.vsix
+          if-no-files-found: error
+
+      - name: Post Comment
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '👋  A new build is available for this PR based on ${{ github.event.pull_request.head.sha }}. Click [here](https://github.com/IBM/vscode-ibmi-projectexplorer/actions/runs/${{ github.run_id }}) to download.'
+            })

--- a/.github/workflows/webpack.yaml
+++ b/.github/workflows/webpack.yaml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build:
+    name: Build and Package
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,8 +79,6 @@ export async function activate(context: ExtensionContext): Promise<IBMiProjectEx
 		await initialise(context);
 	}
 
-	window.showInformationMessage('Workflow Worked!');
-
 	return { projectManager: ProjectManager, projectExplorer: projectExplorer, jobLog: jobLog };
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,8 @@ export async function activate(context: ExtensionContext): Promise<IBMiProjectEx
 		await initialise(context);
 	}
 
+	window.showInformationMessage('Workflow Worked!');
+
 	return { projectManager: ProjectManager, projectExplorer: projectExplorer, jobLog: jobLog };
 }
 


### PR DESCRIPTION
Code4i has this useful workflow which allows them to post a comment on a pull request with a test built VSIX if the build label is added on a pull request. I ported over this same workflow.