### PR TITLE
Fix library commands in Object Browser

### DIFF
--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -480,7 +480,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
           const iProject = ProjectManager.getActiveProject();
 
           if (iProject) {
-            const library = element.name;
+            const library = element.library;
 
             if (library) {
               const selectedPosition = await window.showQuickPick([
@@ -503,7 +503,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
       }),
       commands.registerCommand(`vscode-ibmi-projectexplorer.projectExplorer.setAsCurrentLibrary`, async (element: any) => {
         if (element) {
-          const library = element.name;
+          const library = element.library;
 
           if (library) {
             const iProject = ProjectManager.getActiveProject();
@@ -521,7 +521,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
       }),
       commands.registerCommand(`vscode-ibmi-projectexplorer.projectExplorer.setAsTargetLibraryForCompiles`, async (element: any) => {
         if (element) {
-          const library = element.name;
+          const library = element.library;
 
           if (library) {
             const iProject = ProjectManager.getActiveProject();
@@ -768,7 +768,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
             value = element.label!.toString();
           } else {
             // Invoked from library in Object Browser or directory in IFS Browser
-            value = element.name ? element.name : element.path;
+            value = element.path;
           }
 
           if (value) {


### PR DESCRIPTION
This PR fixes the following commands as a result of an API change in Code4i:
![image](https://github.com/IBM/vscode-ibmi-projectexplorer/assets/32170854/78e6d350-def5-413f-b3d0-91b20b70e2c3)
