### PR TITLE
Fixed call to FS' "Additional Info" command

### DIFF
--- a/src/views/projectExplorer/index.ts
+++ b/src/views/projectExplorer/index.ts
@@ -1436,7 +1436,7 @@ export default class ProjectExplorer implements TreeDataProvider<ProjectExplorer
 }
 
 function toObjectBrowserObject(objectFile: Library | ObjectFile) {
-  const object = Object.assign({}, "objectFileInfo" in objectFile ? objectFile.objectFileInfo : objectFile.libraryInfo);
+  const object = Object.assign({}, "object" in objectFile ? objectFile.object : objectFile.libraryInfo);
   return {
     path: `${object.library}/${object.name}`,
     object,

--- a/src/views/projectExplorer/objectFile.ts
+++ b/src/views/projectExplorer/objectFile.ts
@@ -2,26 +2,26 @@
  * (c) Copyright IBM Corp. 2023
  */
 
+import { IBMiObject } from "@halcyontech/vscode-ibmi-types";
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri, WorkspaceFolder, l10n, window } from "vscode";
-import { ProjectExplorerTreeItem } from "./projectExplorerTreeItem";
-import MemberFile from "./memberFile";
 import { getInstance, getVSCodeTools } from "../../ibmi";
 import { ContextValue } from "../../ibmiProjectExplorer";
-import { IBMiObject } from "@halcyontech/vscode-ibmi-types";
+import MemberFile from "./memberFile";
+import { ProjectExplorerTreeItem } from "./projectExplorerTreeItem";
 
 /**
  * Tree item for an object file.
  */
 export default class ObjectFile extends TreeItem implements ProjectExplorerTreeItem {
   static contextValue = ContextValue.objectFile;
-  objectFileInfo: IBMiObject;
+  object: IBMiObject;
   path: string;
 
   constructor(public workspaceFolder: WorkspaceFolder, objectFileInfo: IBMiObject, pathToLibrary: string) {
     const type = objectFileInfo.type.startsWith(`*`) ? objectFileInfo.type.substring(1) : objectFileInfo.type;
     super(`${objectFileInfo.name}.${type}`);
 
-    this.objectFileInfo = objectFileInfo;
+    this.object = objectFileInfo;
     this.path = `${pathToLibrary}/${objectFileInfo.name}.${type}`;
     this.collapsibleState = objectFileInfo.attribute === 'PF' ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
     this.contextValue = ObjectFile.contextValue +
@@ -42,8 +42,8 @@ export default class ObjectFile extends TreeItem implements ProjectExplorerTreeI
     if (ibmi && connection) {
       const content = connection.getContent();
       const members = await content.getMemberList({
-        library: this.objectFileInfo.library,
-        sourceFile: this.objectFileInfo.name,
+        library: this.object.library,
+        sourceFile: this.object.name,
         members: `*`,
         extensions: `*`,
         sort: { order: 'name' }
@@ -62,21 +62,21 @@ export default class ObjectFile extends TreeItem implements ProjectExplorerTreeI
 
   async getToolTip() {
     const ibmi = getInstance();
-    const path = [this.objectFileInfo.library, this.objectFileInfo.name].join(`/`);
+    const path = [this.object.library, this.object.name].join(`/`);
     const vsCodeTools = getVSCodeTools();
-    if (this.objectFileInfo.sourceFile) {
+    if (this.object.sourceFile) {
       const connection = ibmi?.getConnection();
       if (connection) {
-        return await vsCodeTools?.sourcePhysicalFileToToolTip(connection, path, this.objectFileInfo);
+        return await vsCodeTools?.sourcePhysicalFileToToolTip(connection, path, this.object);
       }
     } else {
-      return vsCodeTools?.objectToToolTip(path, this.objectFileInfo);
+      return vsCodeTools?.objectToToolTip(path, this.object);
     }
   }
 
   getObjectResourceUri() {
-    const type = this.objectFileInfo.type.startsWith(`*`) ? this.objectFileInfo.type.substring(1) : this.objectFileInfo.type;
-    const path = `${this.objectFileInfo.library}/${this.objectFileInfo.name}.${type}`;
+    const type = this.object.type.startsWith(`*`) ? this.object.type.substring(1) : this.object.type;
+    const path = `${this.object.library}/${this.object.name}.${type}`;
     return Uri.parse(path).with({ scheme: `object`, path: `/${path}` });
   }
 }

--- a/src/views/projectExplorer/objectFile.ts
+++ b/src/views/projectExplorer/objectFile.ts
@@ -14,23 +14,22 @@ import { ProjectExplorerTreeItem } from "./projectExplorerTreeItem";
  */
 export default class ObjectFile extends TreeItem implements ProjectExplorerTreeItem {
   static contextValue = ContextValue.objectFile;
-  object: IBMiObject;
   path: string;
 
-  constructor(public workspaceFolder: WorkspaceFolder, objectFileInfo: IBMiObject, pathToLibrary: string) {
-    const type = objectFileInfo.type.startsWith(`*`) ? objectFileInfo.type.substring(1) : objectFileInfo.type;
-    super(`${objectFileInfo.name}.${type}`);
+  constructor(public workspaceFolder: WorkspaceFolder, public readonly object: IBMiObject, pathToLibrary: string) {
+    const type = object.type.startsWith(`*`) ? object.type.substring(1) : object.type;
+    super(`${object.name}.${type}`);
 
-    this.object = objectFileInfo;
-    this.path = `${pathToLibrary}/${objectFileInfo.name}.${type}`;
-    this.collapsibleState = objectFileInfo.attribute === 'PF' ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
+    this.object = object;
+    this.path = `${pathToLibrary}/${object.name}.${type}`;
+    this.collapsibleState = object.attribute === 'PF' ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
     this.contextValue = ObjectFile.contextValue +
       (type ? `.${type}` : ``) +
-      (objectFileInfo.sourceFile ? `.SPF` : ``);
+      (object.sourceFile ? `.SPF` : ``);
     const icon = objectFileIcons.get(type.toLowerCase()) || `file`;
     this.iconPath = new ThemeIcon(icon);
-    this.description = (objectFileInfo.text.trim() !== '' ? `${objectFileInfo.text} ` : ``) +
-      (objectFileInfo.attribute?.trim() !== '' ? `(${objectFileInfo.attribute})` : '');
+    this.description = (object.text.trim() !== '' ? `${object.text} ` : ``) +
+      (object.attribute?.trim() !== '' ? `(${object.attribute})` : '');
     this.resourceUri = this.getObjectResourceUri();
   }
 


### PR DESCRIPTION
## Change
The Code for IBM i FS extension contributes the `vscode-ibmi-fs.dspobj` command that appears on the objects listed in the Project Explorer (let's call that a happy accident 😄 ).

It is the "Additional information" action here:
<img width="395" height="131" alt="image" src="https://github.com/user-attachments/assets/a00bcf38-be6c-4f27-afa2-dc3db15d4997" />

But the command expects to find an `object` field on the node it's being run on.

So this PR fixes the call to this command by renaming the node's `objectFileInfo` field to `object`.

## Test
Right click on an object listed in the Project Explorer and run the "Additional information" action.